### PR TITLE
Fix validation for models without required fields

### DIFF
--- a/module_utils/fdm_swagger_client.py
+++ b/module_utils/fdm_swagger_client.py
@@ -429,7 +429,8 @@ class FdmSwaggerValidator:
             self._add_invalid_type_report(status, path, '', PropType.OBJECT, data)
             return None
 
-        self._check_required_fields(status, model[PropName.REQUIRED], data, path)
+        if PropName.REQUIRED in model:
+            self._check_required_fields(status, model[PropName.REQUIRED], data, path)
 
         model_properties = model[PropName.PROPERTIES]
         for prop in model_properties.keys():

--- a/test/unit/module_utils/test_fdm_swagger_validator.py
+++ b/test/unit/module_utils/test_fdm_swagger_validator.py
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 #
-
+import copy
 import os
 import unittest
 
@@ -603,6 +603,15 @@ class TestFdmSwaggerValidator(unittest.TestCase):
             'value': '1.1.1.1'
         }
         valid, rez = FdmSwaggerValidator(mock_data).validate_data('getNetworkObjectList', data)
+        assert valid
+        assert rez is None
+
+    def test_pass_no_data_with_no_required_fields(self):
+        spec = copy.deepcopy(mock_data)
+        del spec['models']['NetworkObject']['required']
+
+        valid, rez = FdmSwaggerValidator(spec).validate_data('getNetworkObjectList', {})
+
         assert valid
         assert rez is None
 


### PR DESCRIPTION
Some models (e.g., `DeploymentStatus`) do not have any required fields. Our validation used to fail when `PropName.REQUIRED` was absent in a model. This PR fixed this issue.