### PR TITLE
Ignore HTTP errors on login and logout

### DIFF
--- a/test/unit/httpapi_plugins/test_ftd.py
+++ b/test/unit/httpapi_plugins/test_ftd.py
@@ -116,6 +116,15 @@ class TestFtdHttpApi(unittest.TestCase):
 
         assert 'Server returned response without token info during connection authentication' in str(res.exception)
 
+    def test_login_raises_exception_when_http_error(self):
+        self.connection_mock.send.side_effect = HTTPError('http://testhost.com', 400, '', {},
+                                                          StringIO('{"message": "Failed to authenticate user"}'))
+
+        with self.assertRaises(ConnectionError) as res:
+            self.ftd_plugin.login('foo', 'bar')
+
+        assert 'Failed to authenticate user' in str(res.exception)
+
     def test_logout_should_revoke_tokens(self):
         self.ftd_plugin.access_token = 'ACCESS_TOKEN_TO_REVOKE'
         self.ftd_plugin.refresh_token = 'REFRESH_TOKEN_TO_REVOKE'


### PR DESCRIPTION
A bugfix PR. 

When logging in FTD with a wrong API version (e.g., `/api/fdm/v1/fdm/token` instead of `/api/fdm/v2/fdm/token`), `{"message":"Unauthorized","status_code":401}` is returned. `handle_httperror` used to handle such responses as token-related ones and invoke `login` again that resulted in the same error and recursion.

This PR fixes the issue by ignoring HTTP errors (and avoiding retries) when sending `login` and `logout` requests.