### PR TITLE
Make port optional inventory parameter

### DIFF
--- a/docs/static/installation_guide.md
+++ b/docs/static/installation_guide.md
@@ -84,7 +84,7 @@ Here is an example of the inventory file with one local FTD device:
 
 ```
 [ftd]
-localhost ansible_network_os=ftd ansible_user=admin ansible_password=123qwe ansible_httpapi_port=8585
+localhost ansible_network_os=ftd ansible_user=admin ansible_password=123qwe ansible_httpapi_use_ssl=True
 ```
 
 FTD modules __require__ the following host parameters in the inventory file:
@@ -92,13 +92,13 @@ FTD modules __require__ the following host parameters in the inventory file:
 * `ansible_network_os` - an OS of the networking device, must be set to `ftd` when using FTD modules;
 * `ansible_user` - a username for the FTD device;
 * `ansible_password` - a password for the given username;
-* `ansible_httpapi_port` - an HTTP port that the FTD device listens to;
 
 Additionally, these __optional__ parameters can be used:
 
+* `ansible_httpapi_port` - an HTTP port that the FTD device listens to (default is `443` for HTTPS and `80` for HTTP);
+* `ansible_httpapi_use_ssl` - `True` to connect using HTTPS or `False` to connect via HTTP (default is `False`);
 * `ansible_httpapi_ftd_token_path` - a URL for the token endpoint on the FTD device (default URL is `/api/fdm/v2/fdm/token`);
 * `ansible_httpapi_ftd_spec_path` - a URL for the Swagger specification on the FTD device (default URL is `/apispec/ngfw.json`);
-* `ansible_httpapi_use_ssl` - whether to connect using SSL (HTTPS) or not (HTTP);
 * `ansible_httpapi_validate_certs` - Whether to validate SSL certificates or not.
 
 ### Using Vault


### PR DESCRIPTION
Update `Installation Guide` to mention `ansible_httpapi_port` inventory parameter as optional.