### PR TITLE
Set Ansible-specific User-Agent header

### DIFF
--- a/httpapi_plugins/ftd.py
+++ b/httpapi_plugins/ftd.py
@@ -64,7 +64,8 @@ from module_utils.common import HTTPMethod, ResponseParams
 
 BASE_HEADERS = {
     'Content-Type': 'application/json',
-    'Accept': 'application/json'
+    'Accept': 'application/json',
+    'User-Agent': 'FTD Ansible'
 }
 
 TOKEN_EXPIRATION_STATUS_CODE = 408

--- a/httpapi_plugins/ftd.py
+++ b/httpapi_plugins/ftd.py
@@ -50,6 +50,8 @@ import json
 import os
 import re
 
+from ansible import __version__ as ansible_version
+
 from ansible.module_utils.basic import to_text
 from ansible.errors import AnsibleConnectionFailure
 from ansible.module_utils.six.moves.urllib.error import HTTPError
@@ -65,7 +67,7 @@ from module_utils.common import HTTPMethod, ResponseParams
 BASE_HEADERS = {
     'Content-Type': 'application/json',
     'Accept': 'application/json',
-    'User-Agent': 'FTD Ansible'
+    'User-Agent': 'FTD Ansible/%s' % ansible_version
 }
 
 TOKEN_EXPIRATION_STATUS_CODE = 408

--- a/test/unit/httpapi_plugins/test_ftd.py
+++ b/test/unit/httpapi_plugins/test_ftd.py
@@ -37,7 +37,8 @@ else:
 
 EXPECTED_BASE_HEADERS = {
     'Accept': 'application/json',
-    'Content-Type': 'application/json'
+    'Content-Type': 'application/json',
+    'User-Agent': 'FTD Ansible'
 }
 
 

--- a/test/unit/httpapi_plugins/test_ftd.py
+++ b/test/unit/httpapi_plugins/test_ftd.py
@@ -25,7 +25,7 @@ from ansible.module_utils.connection import ConnectionError
 from ansible.module_utils.six import BytesIO, PY3, StringIO
 from ansible.module_utils.six.moves.urllib.error import HTTPError
 
-from httpapi_plugins.ftd import HttpApi
+from httpapi_plugins.ftd import HttpApi, BASE_HEADERS
 
 from module_utils.common import HTTPMethod, ResponseParams
 from module_utils.fdm_swagger_client import FdmSwaggerParser, SpecProp
@@ -34,12 +34,6 @@ if PY3:
     BUILTINS_NAME = 'builtins'
 else:
     BUILTINS_NAME = '__builtin__'
-
-EXPECTED_BASE_HEADERS = {
-    'Accept': 'application/json',
-    'Content-Type': 'application/json',
-    'User-Agent': 'FTD Ansible'
-}
 
 
 class FakeFtdHttpApiPlugin(HttpApi):
@@ -151,7 +145,7 @@ class TestFtdHttpApi(unittest.TestCase):
         assert {ResponseParams.SUCCESS: True, ResponseParams.STATUS_CODE: 200,
                 ResponseParams.RESPONSE: exp_resp} == resp
         self.connection_mock.send.assert_called_once_with('/test/123?at=0', '{"name": "foo"}', method=HTTPMethod.PUT,
-                                                          headers=EXPECTED_BASE_HEADERS)
+                                                          headers=BASE_HEADERS)
 
     def test_send_request_should_return_empty_dict_when_no_response_data(self):
         self.connection_mock.send.return_value = self._connection_response(None)
@@ -160,7 +154,7 @@ class TestFtdHttpApi(unittest.TestCase):
 
         assert {ResponseParams.SUCCESS: True, ResponseParams.STATUS_CODE: 200, ResponseParams.RESPONSE: {}} == resp
         self.connection_mock.send.assert_called_once_with('/test', None, method=HTTPMethod.GET,
-                                                          headers=EXPECTED_BASE_HEADERS)
+                                                          headers=BASE_HEADERS)
 
     def test_send_request_should_return_error_info_when_http_error_raises(self):
         self.connection_mock.send.side_effect = HTTPError('http://testhost.com', 500, '', {},
@@ -235,7 +229,7 @@ class TestFtdHttpApi(unittest.TestCase):
             resp = self.ftd_plugin.upload_file('/tmp/test.txt', '/files')
 
         assert {'id': '123'} == resp
-        exp_headers = dict(EXPECTED_BASE_HEADERS)
+        exp_headers = dict(BASE_HEADERS)
         exp_headers['Content-Length'] = len('--Encoded data--')
         exp_headers['Content-Type'] = 'multipart/form-data'
         self.connection_mock.send.assert_called_once_with('/files', data='--Encoded data--',


### PR DESCRIPTION
To analyze the usage of Ansible modules, we need to identify requests sent by Ansible. This can be done by setting a different `User-Agent` HTTP header.