### PR TITLE
Fix integration tests

### DIFF
--- a/httpapi_plugins/ftd.py
+++ b/httpapi_plugins/ftd.py
@@ -181,7 +181,7 @@ class HttpApi(HttpApiBase):
         # Being invoked via JSON-RPC, this method does not serialize and pass HTTPError correctly to the method caller.
         # Thus, in order to handle non-200 responses, we need to wrap them into a simple structure and pass explicitly.
         except HTTPError as e:
-            error_msg = e.read()
+            error_msg = to_text(e.read())
             self._display(http_method, 'error', error_msg)
             return {
                 ResponseParams.SUCCESS: False,

--- a/samples/test_ftd_configuration_validation.yml
+++ b/samples/test_ftd_configuration_validation.yml
@@ -16,11 +16,13 @@
           - 'result.changed == false'
           - 'result.failed == true'
           - '"Invalid query_params provided" in result.msg'
-          - 'result.msg == {"Invalid query_params provided":
-                            {"invalid_type": [
-                                  {"actually_value": true, "expected_type": "integer", "path": "offset"},
-                                  {"actually_value": 0, "expected_type": "string", "path": "sort"},
-                                  {"actually_value": 1.1, "expected_type": "string", "path": "filter"}]}}'
+          - '3 == result.msg["Invalid query_params provided"]["invalid_type"] | length'
+          - '{"actually_value": true, "expected_type": "integer", "path": "offset"}
+                              in result.msg["Invalid query_params provided"]["invalid_type"]'
+          - '{"actually_value": 0, "expected_type": "string", "path": "sort"}
+                              in result.msg["Invalid query_params provided"]["invalid_type"]'
+          - '{"actually_value": 1.1, "expected_type": "string", "path": "filter"}
+                              in result.msg["Invalid query_params provided"]["invalid_type"]'
 
     - name: 'query_params should contain valid data'
       ftd_configuration:
@@ -69,7 +71,9 @@
         that:
           - 'result.changed == false'
           - 'result.failed == true'
-          - 'result.msg == {"Invalid path_params provided": {"invalid_type": [{"actually_value": 1, "expected_type": "string", "path": "parentId"}]}}'
+          - '1 == result.msg["Invalid path_params provided"]["invalid_type"] | length'
+          - '{"actually_value": 1, "expected_type": "string", "path": "parentId"}
+                              in result.msg["Invalid path_params provided"]["invalid_type"]'
 
     - name: 'edit: path_params should contain all required params'
       ftd_configuration:
@@ -147,15 +151,19 @@
         that:
           - 'result.changed == false'
           - 'result.failed == true'
-          - 'result.msg == {
-                            "Invalid data provided":
-                                {"invalid_type": [
-                                    {"actually_value": false, "expected_type": "string", "path": "name"},
-                                    {"actually_value": true, "expected_type": "string", "path": "description"},
-                                    {"actually_value": "not_enum", "expected_type": "enum", "path": "subType"},
-                                    {"actually_value": 0, "expected_type": "string", "path": "value"},
-                                    {"actually_value": "test", "expected_type": "boolean", "path": "isSystemDefined"},
-                                    {"actually_value": 1, "expected_type": "string", "path": "type"}]}}'
+          - '6 == result.msg["Invalid data provided"]["invalid_type"] | length'
+          - '{"actually_value": false, "expected_type": "string", "path": "name"}
+                              in result.msg["Invalid data provided"]["invalid_type"]'
+          - '{"actually_value": true, "expected_type": "string", "path": "description"}
+                              in result.msg["Invalid data provided"]["invalid_type"]'
+          - '{"actually_value": "not_enum", "expected_type": "enum", "path": "subType"}
+                              in result.msg["Invalid data provided"]["invalid_type"]'
+          - '{"actually_value": 0, "expected_type": "string", "path": "value"}
+                              in result.msg["Invalid data provided"]["invalid_type"]'
+          - '{"actually_value": "test", "expected_type": "boolean", "path": "isSystemDefined"}
+                              in result.msg["Invalid data provided"]["invalid_type"]'
+          - '{"actually_value": 1, "expected_type": "string", "path": "type"}
+                              in result.msg["Invalid data provided"]["invalid_type"]'
 
     - name: data should contain valid data
       ftd_configuration:
@@ -174,12 +182,16 @@
         that:
           - 'result.changed == false'
           - 'result.failed == true'
-          - 'result.msg == {
-                            "Invalid data provided":
-                                {"invalid_type": [
-                                    {"actually_value": 0, "expected_type": "string", "path": "name"},
-                                    {"actually_value": 1.2, "expected_type": "string", "path": "description"},
-                                    {"actually_value": 0, "expected_type": "enum", "path": "subType"},
-                                    {"actually_value": 1, "expected_type": "string", "path": "value"},
-                                    {"actually_value": 1, "expected_type": "boolean", "path": "isSystemDefined"},
-                                    {"actually_value": 1.1, "expected_type": "string", "path": "type"}]}}'
+          - '6 == result.msg["Invalid data provided"]["invalid_type"] | length'
+          - '{"actually_value": 0, "expected_type": "string", "path": "name"}
+                              in result.msg["Invalid data provided"]["invalid_type"]'
+          - '{"actually_value": 1.2, "expected_type": "string", "path": "description"}
+                              in result.msg["Invalid data provided"]["invalid_type"]'
+          - '{"actually_value": 0, "expected_type": "enum", "path": "subType"}
+                              in result.msg["Invalid data provided"]["invalid_type"]'
+          - '{"actually_value": 1, "expected_type": "string", "path": "value"}
+                              in result.msg["Invalid data provided"]["invalid_type"]'
+          - '{"actually_value": 1, "expected_type": "boolean", "path": "isSystemDefined"}
+                              in result.msg["Invalid data provided"]["invalid_type"]'
+          - '{"actually_value": 1.1, "expected_type": "string", "path": "type"}
+                              in result.msg["Invalid data provided"]["invalid_type"]'


### PR DESCRIPTION
This PR fixes the following issues that emerged during integration test runs:
* avoid relying on the element order in dictionaries when comparing validation messages (dictionary order is [preserved in Python 3.6+](https://stackoverflow.com/a/39980744) only);
* always convert error messages to text (initially, they can be byte arrays) before using them in debug statements;