### PR TITLE
Update docs generation logic

### DIFF
--- a/docs/build.py
+++ b/docs/build.py
@@ -10,8 +10,8 @@ from ansible.module_utils._text import to_text
 from ansible.module_utils.urls import open_url
 
 from docs.enricher import ApiSpecAutocomplete
-from docs.generator import ModelDocGenerator, OperationDocGenerator, ModuleDocGenerator, StaticDocGenerator, \
-    ResourceDocGenerator, ErrorDocGenerator, ApiIntroductionDocGenerator
+from docs import generator
+
 from httpapi_plugins.ftd import BASE_HEADERS
 from module_utils.common import HTTPMethod
 from module_utils.fdm_swagger_client import FdmSwaggerParser, SpecProp, OperationField
@@ -166,18 +166,26 @@ def _clean_dist_dir(args):
 
 
 def _generate_ansible_docs(args, api_spec, template_ctx):
-    ModelDocGenerator(DEFAULT_TEMPLATE_DIR, template_ctx, api_spec).generate_doc_files(args.dist, args.models)
-    OperationDocGenerator(DEFAULT_TEMPLATE_DIR, template_ctx, api_spec).generate_doc_files(args.dist, args.models)
-    ModuleDocGenerator(DEFAULT_TEMPLATE_DIR, template_ctx, DEFAULT_MODULE_DIR).generate_doc_files(args.dist)
-    StaticDocGenerator(STATIC_TEMPLATE_DIR, template_ctx).generate_doc_files(args.dist)
+    generator.ModelDocGenerator(DEFAULT_TEMPLATE_DIR, template_ctx, api_spec)\
+        .generate_doc_files(args.dist, args.models)
+    generator.OperationDocGenerator(DEFAULT_TEMPLATE_DIR, template_ctx, api_spec)\
+        .generate_doc_files(args.dist, args.models)
+    generator.ModuleDocGenerator(DEFAULT_TEMPLATE_DIR, template_ctx, DEFAULT_MODULE_DIR)\
+        .generate_doc_files(args.dist)
+    generator.StaticDocGenerator(STATIC_TEMPLATE_DIR, template_ctx)\
+        .generate_doc_files(args.dist)
 
 
 def _generate_ftd_api_docs(args, api_spec, template_ctx, errors_codes):
-    ResourceDocGenerator(DEFAULT_TEMPLATE_DIR, template_ctx, api_spec).generate_doc_files(args.dist, args.models)
-    ModelDocGenerator(DEFAULT_TEMPLATE_DIR, template_ctx, api_spec).generate_doc_files(args.dist, args.models)
-    ApiIntroductionDocGenerator(DEFAULT_TEMPLATE_DIR, template_ctx).generate_doc_files(args.dist)
+    generator.ResourceDocGenerator(DEFAULT_TEMPLATE_DIR, template_ctx, api_spec)\
+        .generate_doc_files(args.dist, args.models)
+    generator.APIModelDocGenerator(DEFAULT_TEMPLATE_DIR, template_ctx, api_spec)\
+        .generate_doc_files(args.dist, args.models)
+    generator.ApiIntroductionDocGenerator(DEFAULT_TEMPLATE_DIR, template_ctx)\
+        .generate_doc_files(args.dist)
     if errors_codes:
-        ErrorDocGenerator(DEFAULT_TEMPLATE_DIR, template_ctx).generate_doc_files(args.dist, errors_codes)
+        generator.ErrorDocGenerator(DEFAULT_TEMPLATE_DIR, template_ctx)\
+            .generate_doc_files(args.dist, errors_codes)
 
 
 def _generate_docs(args, api_client):

--- a/docs/build.py
+++ b/docs/build.py
@@ -179,7 +179,7 @@ def _generate_ansible_docs(args, api_spec, template_ctx):
 def _generate_ftd_api_docs(args, api_spec, template_ctx, errors_codes):
     generator.ResourceDocGenerator(DEFAULT_TEMPLATE_DIR, template_ctx, api_spec)\
         .generate_doc_files(args.dist, args.models)
-    generator.APIModelDocGenerator(DEFAULT_TEMPLATE_DIR, template_ctx, api_spec)\
+    generator.ModelDocGenerator(DEFAULT_TEMPLATE_DIR, template_ctx, api_spec) \
         .generate_doc_files(args.dist, args.models)
     generator.ApiIntroductionDocGenerator(DEFAULT_TEMPLATE_DIR, template_ctx)\
         .generate_doc_files(args.dist)

--- a/docs/generator.py
+++ b/docs/generator.py
@@ -15,6 +15,7 @@ from module_utils.fdm_swagger_client import SpecProp, OperationField, PropName, 
     PropType
 from httpapi_plugins.ftd import BASE_HEADERS
 from docs.snippets_generation import swagger_ui_bravado, swagger_ui_curlify
+from docs import utils
 
 ModelSpec = namedtuple('ModelSpec', 'name description properties operations')
 OperationSpec = namedtuple('OperationSpec', 'name description model_name path_params query_params data_params')
@@ -123,11 +124,7 @@ class ApiSpecDocGenerator(BaseDocGenerator):
 
         model_name = self._get_model_name_from_op_spec(op_spec)
         data_params = self._get_model_properties(model_name)
-
-        if op_name.startswith('add') and op_method == HTTPMethod.POST:
-            data_params = {k: v for k, v in data_params.items() if k not in IDENTITY_PROPERTIES}
-
-        return data_params
+        return utils.filter_data_params(op_name, op_method, data_params)
 
 
 class ModelDocGenerator(ApiSpecDocGenerator):

--- a/docs/generator.py
+++ b/docs/generator.py
@@ -137,7 +137,6 @@ class ModelDocGenerator(ApiSpecDocGenerator):
 
     def __init__(self, template_dir, template_ctx, api_spec):
         super().__init__(template_dir, template_ctx, api_spec)
-        self._model_index = []
         self._model_template = self._jinja_env.get_template(self.MODEL_TEMPLATE)
         self._model_dir = None
 
@@ -176,6 +175,8 @@ class ModelDocGenerator(ApiSpecDocGenerator):
             self._process_single_model(model_name, operations)
 
     def generate_doc_files(self, dest_dir, include_models=None):
+        self._model_index = []
+
         self._model_dir = os.path.join(dest_dir, 'models')
 
         self._process_models(include_models)

--- a/docs/jinja_filters.py
+++ b/docs/jinja_filters.py
@@ -4,11 +4,24 @@ from module_utils.fdm_swagger_client import SpecProp, PropName, PropType
 
 
 def camel_to_snake(text):
+    """
+    Lookup and replace words in camelCaseFormat with same words in snake_format.
+
+    :param text: string value.
+    :return: updated text value
+    """
     test_with_underscores = re.sub('(.)([A-Z][a-z]+)', r'\1_\2', text)
     return re.sub('([a-z0-9])([A-Z])', r'\1_\2', test_with_underscores).lower()
 
 
 def get_link_to_model_page_by_name(model_name, display_name="object"):
+    """
+    Generates Markdown hyperlink statement for particular model.
+
+    :param model_name: string value
+    :param display_name: string value to be displayed as hyperlink text. default value is "object"
+    :return: string value which represents Markdown hyperlink statement
+    """
     return "[{}]{}".format(display_name, _get_link_path(model_name))
 
 
@@ -17,7 +30,14 @@ def _get_link_path(model_name):
 
 
 def show_type_or_reference(data_param_spec, api_spec=None):
+    """
+    Check if particular data parameter represents complex data type but not Enum and generate
+    Markdown hyperlink statement which leads user to page with complex data type description.
 
+    :param data_param_spec: dict object with swagger specification of data param
+    :param api_spec: dict object which represents complete API spec
+    :return: string value which represents simple type or hyperlink to complex type
+    """
     data_param_type = data_param_spec[PropName.TYPE]
 
     def ref_to_model_name(ref_address):
@@ -55,6 +75,13 @@ def show_type_or_reference(data_param_spec, api_spec=None):
 
 
 def show_description_with_references(description):
+    """
+    Check if any complex data type mentioned in the description, if so - name of the complex data type replaced with
+    hyperlink to page with corresponding data type definition.
+
+    :param description: string value to be checked
+    :return: updated description values
+    """
     matched_model_names = re.findall("types are: &#91;(.*)&#93;", description)
     if not matched_model_names:
         return description

--- a/docs/jinja_filters.py
+++ b/docs/jinja_filters.py
@@ -1,0 +1,72 @@
+import re
+
+from module_utils.fdm_swagger_client import SpecProp, PropName, PropType
+
+
+def camel_to_snake(text):
+    test_with_underscores = re.sub('(.)([A-Z][a-z]+)', r'\1_\2', text)
+    return re.sub('([a-z0-9])([A-Z])', r'\1_\2', test_with_underscores).lower()
+
+
+def get_link_to_model_page_by_name(model_name, display_name="object"):
+    return "[{}]{}".format(display_name, _get_link_path(model_name))
+
+
+def _get_link_path(model_name):
+    return "(/models/{}.md)".format(camel_to_snake(model_name))
+
+
+def show_type_or_reference(data_param_spec, api_spec=None):
+
+    data_param_type = data_param_spec[PropName.TYPE]
+
+    def ref_to_model_name(ref_address):
+        return ref_address.replace("#/definitions/", "")
+
+    def default_value():
+        return data_param_type
+
+    def process_array():
+        ref_name = data_param_spec[PropName.ITEMS].get(PropName.REF)
+        if ref_name:
+            model = ref_to_model_name(ref_name)
+            return "[{}]".format(get_link_to_model_page_by_name(model))
+
+        return "[{}]".format(data_param_spec[PropName.ITEMS][PropName.TYPE])
+
+    def process_object():
+        if PropName.REF not in data_param_spec:
+            return default_value()
+
+        model = ref_to_model_name(data_param_spec[PropName.REF])
+        model_api_spec = api_spec[SpecProp.MODELS].get(model, {})
+
+        if PropName.ENUM in model_api_spec:
+            return model_api_spec.get(PropName.TYPE, data_param_type)
+
+        return get_link_to_model_page_by_name(model)
+
+    decision_map = {
+        PropType.ARRAY: process_array,
+        PropType.OBJECT: process_object
+    }
+
+    return decision_map.get(data_param_type, default_value)()
+
+
+def show_description_with_references(description):
+    matched_model_names = re.findall("types are: &#91;(.*)&#93;", description)
+    if not matched_model_names:
+        return description
+
+    model_names = matched_model_names[0].split(', ')
+
+    linked_model_names = [
+        get_link_to_model_page_by_name(model, display_name=model)
+        for model in model_names
+    ]
+
+    return description.replace(
+        matched_model_names[0],
+        ", ".join(linked_model_names)
+    )

--- a/docs/snippets_generation/swagger_ui_bravado.py
+++ b/docs/snippets_generation/swagger_ui_bravado.py
@@ -1,4 +1,7 @@
+from module_utils.fdm_swagger_client import OperationField
+
 from docs.snippets_generation import body_generator
+from docs import utils
 
 
 def generate_sample(op_name, op_spec, data_params_are_present, model_name, full_spec, jinja_env):
@@ -13,6 +16,7 @@ def generate_sample(op_name, op_spec, data_params_are_present, model_name, full_
             model_name,
             full_spec
         )
+        body = utils.filter_data_params(op_name, op_spec[OperationField.METHOD], body)
         operation_arguments["body"] = str(body).replace(', ', ", \n\t\t")
 
     template = jinja_env.get_template(template_name)

--- a/docs/snippets_generation/swagger_ui_bravado.py
+++ b/docs/snippets_generation/swagger_ui_bravado.py
@@ -1,3 +1,5 @@
+from pprint import PrettyPrinter
+
 from module_utils.fdm_swagger_client import OperationField
 
 from docs.snippets_generation import body_generator
@@ -17,7 +19,8 @@ def generate_sample(op_name, op_spec, data_params_are_present, model_name, full_
             full_spec
         )
         body = utils.filter_data_params(op_name, op_spec[OperationField.METHOD], body)
-        operation_arguments["body"] = str(body).replace(', ', ", \n\t\t")
+        printer = PrettyPrinter(width=1)
+        operation_arguments["body"] = printer.pformat(body)
 
     template = jinja_env.get_template(template_name)
     return template.render(

--- a/docs/snippets_generation/swagger_ui_curlify.py
+++ b/docs/snippets_generation/swagger_ui_curlify.py
@@ -11,7 +11,7 @@ def generate_sample(op_spec, data_params_are_present, model_name, full_spec, bas
     headers = dict(base_headers)
     # add mandatory token
     headers["Authorization"] = 'Bearer ${ACCESS_TOKEN}'
-
+    headers.pop('User-Agent', None)
     if data_params_are_present:
         body = body_generator.generate_model_sample(model_name, full_spec)
 

--- a/docs/snippets_generation/swagger_ui_curlify.py
+++ b/docs/snippets_generation/swagger_ui_curlify.py
@@ -5,14 +5,15 @@ Original implementation: https://github.com/swagger-api/swagger-ui/blob/master/s
 from docs.snippets_generation import body_generator
 
 
-def generate_sample(op_spec, data_params_are_present, model_name, full_spec, base_headers, jinja_env):
+def generate_sample(op_spec, data_params_are_present, model_name, full_spec, jinja_env):
     body = None
     template_name = "snippet_curl.j2"
-    headers = dict(base_headers)
-    # add mandatory token
-    headers["Authorization"] = 'Bearer ${ACCESS_TOKEN}'
-    headers.pop('User-Agent', None)
+    headers = {
+        "Accept": "application/json",
+        "Authorization": "Bearer ${ACCESS_TOKEN}"
+    }
     if data_params_are_present:
+        headers["Content-Type"] = "application/json"
         body = body_generator.generate_model_sample(model_name, full_spec)
 
     template = jinja_env.get_template(template_name)

--- a/docs/templates/includes/data_params.j2
+++ b/docs/templates/includes/data_params.j2
@@ -4,6 +4,6 @@
 | Parameter | Required | Type | Description |
 | --------- | -------- | ---- | ----------- |
 {% for param_name, param_spec in data_params.items() %}
-| {{ param_name }} | {{ param_spec.required }} | {{ param_spec.type }} <td colspan=3> {{ param_spec.description | escape_md_symbols }} |
+| {{ param_name }} | {{ param_spec.required }} | {{ param_spec | show_type_or_reference }} <td colspan=3> {{ param_spec.description | escape_md_symbols | show_description_with_references }} |
 {% endfor %}
 {% endif %}

--- a/docs/templates/includes/model_params.j2
+++ b/docs/templates/includes/model_params.j2
@@ -4,6 +4,6 @@
 | Property | Required | Type | Description |
 | -------- | -------- | ---- | ----------- |
 {% for property_name, property_spec in model_properties.items() %}
-| {{ property_name }} | {{ property_spec.required }} | {{ property_spec.type }} | {{ property_spec.description | escape_md_symbols }} |
+| {{ property_name }} | {{ property_spec.required }} | {{ property_spec | show_type_or_reference }} <td colspan=3>  {{ property_spec.description | escape_md_symbols | show_description_with_references }} |
 {% endfor %}
 {% endif %}

--- a/docs/templates/includes/operation_description.j2
+++ b/docs/templates/includes/operation_description.j2
@@ -1,0 +1,1 @@
+The {{ name }} operation handles configuration related to {{ model_name | get_link_to_model_page_by_name(model_name) }} model.

--- a/docs/templates/includes/operation_description.j2
+++ b/docs/templates/includes/operation_description.j2
@@ -1,1 +1,1 @@
-The {{ name }} operation handles configuration related to {{ model_name | get_link_to_model_page_by_name(model_name) }} model.
+The {{ name }} operation handles configuration related to {{ model_name | get_link_to_model_page_by_name(model_name) }} model.&nbsp;

--- a/docs/templates/intro.md.j2
+++ b/docs/templates/intro.md.j2
@@ -20,11 +20,11 @@ The API is has its own version number. There is no guarantee that a client desig
 
 In general, your client interacts with a <span>Firepower Threat Defense</span> device using the following iterative process:
 
-1.  Obtain an access token to authenticate your API calls. See [Overview of the API Client Authentication Process](auth.md).
+1.  Obtain an access token to authenticate your API calls. See [Overview of the API Client Authentication Process](/introduction/auth.md).
 1.  Except when simply reading data, build a JSON payload.
 1.  Transmit the JSON payload using an HTTPS call for the Universal Resource Locator (URL) for the resource.
 1.  Consume the returned JSON response.
-1.  If you make configuration changes, deploy the changes. See [Deploying Configuration Changes](deploy_config.md).
+1.  If you make configuration changes, deploy the changes. See [Deploying Configuration Changes](/introduction/deploy_config.md).
 
 ### Supported HTTP Methods
 

--- a/docs/templates/intro.md.j2
+++ b/docs/templates/intro.md.j2
@@ -20,11 +20,11 @@ The API is has its own version number. There is no guarantee that a client desig
 
 In general, your client interacts with a <span>Firepower Threat Defense</span> device using the following iterative process:
 
-1.  Obtain an access token to authenticate your API calls. See [Overview of the API Client Authentication Process](auth.md.j2).
+1.  Obtain an access token to authenticate your API calls. See [Overview of the API Client Authentication Process](auth.md).
 1.  Except when simply reading data, build a JSON payload.
 1.  Transmit the JSON payload using an HTTPS call for the Universal Resource Locator (URL) for the resource.
 1.  Consume the returned JSON response.
-1.  If you make configuration changes, deploy the changes. See [Deploying Configuration Changes](deploy_config.md.j2).
+1.  If you make configuration changes, deploy the changes. See [Deploying Configuration Changes](deploy_config.md).
 
 ### Supported HTTP Methods
 

--- a/docs/templates/operation.md.j2
+++ b/docs/templates/operation.md.j2
@@ -1,7 +1,9 @@
 # {{ operation.name }}
 
 {% if operation.model_name%}
-The [{{ operation.name }}]({{ operation.name | camel_to_snake }}.md) operation handles configuration related to [{{ operation.model_name }}](../models/{{ operation.model_name | camel_to_snake }}.md) model.
+{% with name = operation.name,  model_name = operation.model_name %}
+{% include 'includes/operation_description.j2' %}
+{% endwith %}
 {% endif %}
 
 {% if operation.description %}

--- a/docs/templates/resource_operation.md.j2
+++ b/docs/templates/resource_operation.md.j2
@@ -1,6 +1,12 @@
-{% if description %}
+{% if model_name or description %}
 ## Description
+{% if model_name %}
+{% include 'includes/operation_description.j2' %}
+
+{% endif %}
+{% if description %}
 {{ description | escape_md_symbols }}
+{% endif %}
 {% endif %}
 
 ## HTTP request

--- a/docs/templates/snippet_bravado.j2
+++ b/docs/templates/snippet_bravado.j2
@@ -6,7 +6,7 @@ def get_client(host, token):
     http_client = RequestsClient()
     http_client.ssl_verify = False
     http_client.set_api_key(
-         host,
+        host,
         "Bearer {}".format(token),
         param_name="Authorization",
         param_in="header"

--- a/docs/utils.py
+++ b/docs/utils.py
@@ -1,0 +1,10 @@
+from module_utils.common import HTTPMethod, IDENTITY_PROPERTIES
+
+
+def filter_data_params(op_name, op_method, data_params):
+    blocked_properties = []
+
+    if op_name.startswith('add') and op_method == HTTPMethod.POST:
+        blocked_properties = IDENTITY_PROPERTIES
+
+    return {k: v for k, v in data_params.items() if k not in blocked_properties}


### PR DESCRIPTION
In the scope of this PR were introduced following improvements:
- fixed links at introduction page;
- added links from operation page to corresponding mode page;
- at the params section - complex types names extended with links to corresponding types description;
- at the params section - model names in the description column extended with links to corresponding pages;
- More models added to ansible documentation to ensure that all hyperlinks to model pages work properly.