### PR TITLE
Upsert operation for noncreatable objects

### DIFF
--- a/docs/build.py
+++ b/docs/build.py
@@ -30,7 +30,7 @@ class FtdApiClient(object):
     and token-related aspects.
     """
 
-    SUPPORTED_VERSIONS = ['v2', 'v1']
+    SUPPORTED_VERSIONS = ['latest', 'v3', 'v2', 'v1']
     TOKEN_PATH_TEMPLATE = '/api/fdm/{}/fdm/token'
 
     SPEC_PATH = '/apispec/ngfw.json'

--- a/docs/enricher.py
+++ b/docs/enricher.py
@@ -23,8 +23,8 @@ class ApiSpecAutocomplete(object):
     def _add_operation_to_operations_spec(self, op_name, op_spec):
         self._api_spec[SpecProp.OPERATIONS][op_name] = op_spec
 
-    def _generate_upsert_spec(self, operations, model_name, add_operantion, list_operation):
-        op_spec = dict(operations[add_operantion])
+    def _generate_upsert_spec(self, operations, model_name, edit_operation, list_operation):
+        op_spec = dict(operations[edit_operation])
         base_filter_spec = dict(
             operations[list_operation][OperationField.PARAMETERS][OperationParams.QUERY][QueryParams.FILTER])
 
@@ -49,12 +49,12 @@ class ApiSpecAutocomplete(object):
             # Some actions will have no model - we can't do upsert for them.
             return
 
-        add_operantion = OperationNamePrefix.ADD + model_name
+        edit_operation = OperationNamePrefix.EDIT + model_name
         list_operation = OperationNamePrefix.GET + model_name + 'List'
 
         if self._operation_checker.is_upsert_operation_supported(operations):
             op_name = OperationNamePrefix.UPSERT + model_name
-            op_spec = self._generate_upsert_spec(operations, model_name, add_operantion, list_operation)
+            op_spec = self._generate_upsert_spec(operations, model_name, edit_operation, list_operation)
 
             self._add_operation_to_model_spec(
                 model_name=model_name,

--- a/module_utils/configuration.py
+++ b/module_utils/configuration.py
@@ -198,7 +198,8 @@ class OperationChecker(object):
         :rtype: bool
         """
         has_edit_op = next((name for name, spec in iteritems(operations) if cls.is_edit_operation(name, spec)), None)
-        has_get_list_op = next((name for name, spec in iteritems(operations) if cls.is_get_list_operation(name, spec)), None)
+        has_get_list_op = next((name for name, spec in iteritems(operations)
+                                if cls.is_get_list_operation(name, spec)), None)
         return has_edit_op and has_get_list_op
 
 
@@ -474,7 +475,8 @@ class BaseConfigurationResource(object):
         existing_obj = self._find_object_matching_params(model_name, params)
         if existing_obj:
             equal_to_existing_obj = equal_objects(existing_obj, params[ParamName.DATA])
-            return existing_obj if equal_to_existing_obj else self._edit_upserted_object(model_operations, existing_obj, params)
+            return existing_obj if equal_to_existing_obj \
+                else self._edit_upserted_object(model_operations, existing_obj, params)
         else:
             return self._add_upserted_object(model_operations, params)
 

--- a/module_utils/configuration.py
+++ b/module_utils/configuration.py
@@ -419,19 +419,6 @@ class BaseConfigurationResource(object):
         if report:
             raise ValidationError(report)
 
-    def is_upsert_operation_supported(self, op_name):
-        """
-        Checks if all operations required for upsert object operation are defined in 'operations'.
-
-        :param op_name: upsert operation name
-        :type op_name: str
-        :return: True if all criteria required to provide requested called operation are satisfied, otherwise False
-        :rtype: bool
-        """
-        model_name = _extract_model_from_upsert_operation(op_name)
-        operations = self.get_operation_specs_by_model_name(model_name)
-        return self._operation_checker.is_upsert_operation_supported(operations)
-
     @staticmethod
     def _get_operation_name(checker, operations):
         for operation_name, op_spec in operations.items():
@@ -465,11 +452,11 @@ class BaseConfigurationResource(object):
         :return: upserted object representation
         :rtype: dict
         """
-        if not self.is_upsert_operation_supported(op_name):
-            raise FtdInvalidOperationNameError(op_name)
-
         model_name = _extract_model_from_upsert_operation(op_name)
         model_operations = self.get_operation_specs_by_model_name(model_name)
+
+        if not self._operation_checker.is_upsert_operation_supported(model_operations):
+            raise FtdInvalidOperationNameError(op_name)
 
         try:
             return self._add_upserted_object(model_operations, params)

--- a/module_utils/configuration.py
+++ b/module_utils/configuration.py
@@ -189,15 +189,9 @@ class OperationChecker(object):
         :return: True if all criteria required to provide requested called operation are satisfied, otherwise False
         :rtype: bool
         """
-        amount_operations_need_for_upsert_operation = 3
-        amount_supported_operations = 0
-        for operation_name, operation_spec in operations.items():
-            if cls.is_add_operation(operation_name, operation_spec) \
-                    or cls.is_edit_operation(operation_name, operation_spec) \
-                    or cls.is_get_list_operation(operation_name, operation_spec):
-                amount_supported_operations += 1
-
-        return amount_supported_operations == amount_operations_need_for_upsert_operation
+        has_edit_operation = next((name for name, spec in operations.items() if cls.is_edit_operation(name, spec)), None)
+        has_get_list_operation = next((name for name, spec in operations.items() if cls.is_get_list_operation(name, spec)), None)
+        return has_edit_operation and has_get_list_operation
 
 
 class BaseConfigurationResource(object):

--- a/samples/physical_interface.yml
+++ b/samples/physical_interface.yml
@@ -1,0 +1,48 @@
+- hosts: all
+  connection: httpapi
+  tasks:
+    - name: Setup Outside Interface
+      ftd_configuration:
+        operation: upsertPhysicalInterface
+        data:
+          name: outside
+          hardwareName: GigabitEthernet0/2
+          monitorInterface: true
+          ipv4:
+            addressNull: FALSE
+            defaultRouteUsingDHCP: FALSE
+            dhcp: FALSE
+            ipAddress:
+              ipAddress: 192.168.10.2
+              netmask: 255.255.255.0
+              standbyIpAddress: 192.168.10.3
+              type: haipv4address
+            ipType: STATIC
+            type: interfaceipv4
+          mtu: 1500
+          enabled: TRUE
+          mode: ROUTED
+          type: physicalinterface
+
+    - name: Setup Inside Interface
+      ftd_configuration:
+        operation: upsertPhysicalInterface
+        data:
+          name: inside
+          hardwareName: GigabitEthernet0/1
+          monitorInterface: true
+          ipv4:
+            addressNull: FALSE
+            defaultRouteUsingDHCP: FALSE
+            dhcp: FALSE
+            ipAddress:
+              ipAddress: 192.168.20.2
+              netmask: 255.255.255.0
+              standbyIpAddress: 192.168.20.3
+              type: haipv4address
+            ipType: STATIC
+            type: interfaceipv4
+          mtu: 1500
+          enabled: TRUE
+          mode: ROUTED
+          type: physicalinterface

--- a/test/unit/module_utils/test_configuration.py
+++ b/test/unit/module_utils/test_configuration.py
@@ -547,29 +547,14 @@ class TestOperationCheckerClass(unittest.TestCase):
             operation_name, params, operation_spec
         )
 
-    @patch.object(OperationChecker, "is_add_operation")
-    @patch.object(OperationChecker, "is_edit_operation")
-    @patch.object(OperationChecker, "is_get_list_operation")
-    def test_is_upsert_operation_supported_operation(self, is_add_mock, is_edit_mock, is_get_list_mock):
-        operations_spec = {
-            'add': 1,
-            'edit': 1,
-            'getList': 1
-        }
-        is_add_mock.side_effect = [1, 0, 0]
-        is_edit_mock.side_effect = [1, 0, 0]
-        is_get_list_mock.side_effect = [1, 0, 0]
+    def test_is_upsert_operation_supported_operation(self):
+        get_list_op_spec = {OperationField.METHOD: HTTPMethod.GET, OperationField.RETURN_MULTIPLE_ITEMS: True}
+        add_op_spec = {OperationField.METHOD: HTTPMethod.POST}
+        edit_op_spec = {OperationField.METHOD: HTTPMethod.PUT}
 
-        assert self._checker.is_upsert_operation_supported(operations_spec)
-
-        is_add_mock.side_effect = [1, 0, 0]
-        is_edit_mock.side_effect = [0, 1, 0]
-        is_get_list_mock.side_effect = [0, 0, 0]
-
-        assert not self._checker.is_upsert_operation_supported(operations_spec)
-
-        is_add_mock.side_effect = [1, 0, 0]
-        is_edit_mock.side_effect = [0, 0, 0]
-        is_get_list_mock.side_effect = [1, 0, 0]
-
-        assert not self._checker.is_upsert_operation_supported(operations_spec)
+        assert self._checker.is_upsert_operation_supported({'getList': get_list_op_spec, 'edit': edit_op_spec})
+        assert self._checker.is_upsert_operation_supported(
+            {'add': add_op_spec, 'getList': get_list_op_spec, 'edit': edit_op_spec})
+        assert not self._checker.is_upsert_operation_supported({'getList': get_list_op_spec})
+        assert not self._checker.is_upsert_operation_supported({'edit': edit_op_spec})
+        assert not self._checker.is_upsert_operation_supported({'getList': get_list_op_spec, 'add': add_op_spec})

--- a/test/unit/module_utils/test_upsert_functionality.py
+++ b/test/unit/module_utils/test_upsert_functionality.py
@@ -171,7 +171,8 @@ class TestUpsertOperationUnitTests(unittest.TestCase):
     @mock.patch.object(BaseConfigurationResource, "_edit_upserted_object")
     @mock.patch("module_utils.configuration._extract_model_from_upsert_operation")
     def test_upsert_object_returned_without_modifications(self, extract_model_mock, edit_mock, add_mock, find_object,
-                                                          get_operation_mock, is_upsert_supported_mock, equal_objects_mock):
+                                                          get_operation_mock, is_upsert_supported_mock,
+                                                          equal_objects_mock):
         op_name = mock.MagicMock()
         params = mock.MagicMock()
         existing_obj = mock.MagicMock()
@@ -223,7 +224,8 @@ class TestUpsertOperationUnitTests(unittest.TestCase):
     @mock.patch.object(BaseConfigurationResource, "_edit_upserted_object")
     @mock.patch("module_utils.configuration._extract_model_from_upsert_operation")
     def test_upsert_object_with_fatal_error_during_edit(self, extract_model_mock, edit_mock, add_mock, find_object,
-                                                        get_operation_mock, is_upsert_supported_mock, equal_objects_mock):
+                                                        get_operation_mock, is_upsert_supported_mock,
+                                                        equal_objects_mock):
         op_name = mock.MagicMock()
         params = mock.MagicMock()
         existing_obj = mock.MagicMock()

--- a/test/unit/module_utils/test_upsert_functionality.py
+++ b/test/unit/module_utils/test_upsert_functionality.py
@@ -1,10 +1,10 @@
 from __future__ import absolute_import
 
-import pytest
-import json
 import copy
+import json
 import unittest
 
+import pytest
 from ansible.compat.tests import mock
 
 try:
@@ -17,7 +17,6 @@ except ImportError:
     from module_utils.configuration import DUPLICATE_NAME_ERROR_MESSAGE, UNPROCESSABLE_ENTITY_STATUS, \
         MULTIPLE_DUPLICATES_FOUND_ERROR, BaseConfigurationResource, FtdInvalidOperationNameError, QueryParams
     from module_utils.fdm_swagger_client import ValidationError
-
 
 ADD_RESPONSE = {'status': 'Object added'}
 EDIT_RESPONSE = {'status': 'Object edited'}
@@ -101,20 +100,7 @@ class TestUpsertOperationUnitTests(unittest.TestCase):
             params
         )
 
-    @mock.patch.object(BaseConfigurationResource, "get_operation_specs_by_model_name")
     @mock.patch("module_utils.configuration.OperationChecker.is_upsert_operation_supported")
-    @mock.patch("module_utils.configuration._extract_model_from_upsert_operation")
-    def test_is_upsert_operation_supported(self, extract_model_mock, is_upsert_supported_mock, get_operation_spec_mock):
-        op_name = mock.MagicMock()
-
-        result = self._resource.is_upsert_operation_supported(op_name)
-
-        assert result == is_upsert_supported_mock.return_value
-        extract_model_mock.assert_called_once_with(op_name)
-        get_operation_spec_mock.assert_called_once_with(extract_model_mock.return_value)
-        is_upsert_supported_mock.assert_called_once_with(get_operation_spec_mock.return_value)
-
-    @mock.patch.object(BaseConfigurationResource, "is_upsert_operation_supported")
     @mock.patch.object(BaseConfigurationResource, "get_operation_specs_by_model_name")
     @mock.patch.object(BaseConfigurationResource, "_add_upserted_object")
     @mock.patch.object(BaseConfigurationResource, "_edit_upserted_object")
@@ -129,13 +115,13 @@ class TestUpsertOperationUnitTests(unittest.TestCase):
         result = self._resource.upsert_object(op_name, params)
 
         assert result == add_mock.return_value
-        is_upsert_supported_mock.assert_called_once_with(op_name)
+        is_upsert_supported_mock.assert_called_once_with(get_operation_mock.return_value)
         extract_model_mock.assert_called_once_with(op_name)
         get_operation_mock.assert_called_once_with(extract_model_mock.return_value)
         add_mock.assert_called_once_with(get_operation_mock.return_value, params)
         edit_mock.assert_not_called()
 
-    @mock.patch.object(BaseConfigurationResource, "is_upsert_operation_supported")
+    @mock.patch("module_utils.configuration.OperationChecker.is_upsert_operation_supported")
     @mock.patch.object(BaseConfigurationResource, "get_operation_specs_by_model_name")
     @mock.patch.object(BaseConfigurationResource, "_add_upserted_object")
     @mock.patch.object(BaseConfigurationResource, "_edit_upserted_object")
@@ -154,13 +140,13 @@ class TestUpsertOperationUnitTests(unittest.TestCase):
         result = self._resource.upsert_object(op_name, params)
 
         assert result == edit_mock.return_value
-        is_upsert_supported_mock.assert_called_once_with(op_name)
         extract_model_mock.assert_called_once_with(op_name)
         get_operation_mock.assert_called_once_with(extract_model_mock.return_value)
+        is_upsert_supported_mock.assert_called_once_with(get_operation_mock.return_value)
         add_mock.assert_called_once_with(get_operation_mock.return_value, params)
         edit_mock.assert_called_once_with(get_operation_mock.return_value, error.obj, params)
 
-    @mock.patch.object(BaseConfigurationResource, "is_upsert_operation_supported")
+    @mock.patch("module_utils.configuration.OperationChecker.is_upsert_operation_supported")
     @mock.patch.object(BaseConfigurationResource, "get_operation_specs_by_model_name")
     @mock.patch.object(BaseConfigurationResource, "_add_upserted_object")
     @mock.patch.object(BaseConfigurationResource, "_edit_upserted_object")
@@ -177,13 +163,13 @@ class TestUpsertOperationUnitTests(unittest.TestCase):
             self._resource.upsert_object, op_name, params
         )
 
-        is_upsert_supported_mock.assert_called_once_with(op_name)
-        extract_model_mock.assert_not_called()
-        get_operation_mock.assert_not_called()
+        extract_model_mock.assert_called_once_with(op_name)
+        get_operation_mock.assert_called_once_with(extract_model_mock.return_value)
+        is_upsert_supported_mock.assert_called_once_with(get_operation_mock.return_value)
         add_mock.assert_not_called()
         edit_mock.assert_not_called()
 
-    @mock.patch.object(BaseConfigurationResource, "is_upsert_operation_supported")
+    @mock.patch("module_utils.configuration.OperationChecker.is_upsert_operation_supported")
     @mock.patch.object(BaseConfigurationResource, "get_operation_specs_by_model_name")
     @mock.patch.object(BaseConfigurationResource, "_add_upserted_object")
     @mock.patch.object(BaseConfigurationResource, "_edit_upserted_object")
@@ -205,13 +191,13 @@ class TestUpsertOperationUnitTests(unittest.TestCase):
             self._resource.upsert_object, op_name, params
         )
 
-        is_upsert_supported_mock.assert_called_once_with(op_name)
+        is_upsert_supported_mock.assert_called_once_with(get_operation_mock.return_value)
         extract_model_mock.assert_called_once_with(op_name)
         get_operation_mock.assert_called_once_with(extract_model_mock.return_value)
         add_mock.assert_called_once_with(get_operation_mock.return_value, params)
         edit_mock.assert_called_once_with(get_operation_mock.return_value, error.obj, params)
 
-    @mock.patch.object(BaseConfigurationResource, "is_upsert_operation_supported")
+    @mock.patch("module_utils.configuration.OperationChecker.is_upsert_operation_supported")
     @mock.patch.object(BaseConfigurationResource, "get_operation_specs_by_model_name")
     @mock.patch.object(BaseConfigurationResource, "_add_upserted_object")
     @mock.patch.object(BaseConfigurationResource, "_edit_upserted_object")
@@ -231,7 +217,7 @@ class TestUpsertOperationUnitTests(unittest.TestCase):
             self._resource.upsert_object, op_name, params
         )
 
-        is_upsert_supported_mock.assert_called_once_with(op_name)
+        is_upsert_supported_mock.assert_called_once_with(get_operation_mock.return_value)
         extract_model_mock.assert_called_once_with(op_name)
         get_operation_mock.assert_called_once_with(extract_model_mock.return_value)
         add_mock.assert_called_once_with(get_operation_mock.return_value, params)

--- a/test/unit/module_utils/test_upsert_functionality.py
+++ b/test/unit/module_utils/test_upsert_functionality.py
@@ -10,12 +10,14 @@ from ansible.compat.tests import mock
 try:
     from ansible.module_utils.common import FtdServerError, HTTPMethod, ResponseParams, FtdConfigurationError
     from ansible.module_utils.configuration import DUPLICATE_NAME_ERROR_MESSAGE, UNPROCESSABLE_ENTITY_STATUS, \
-        MULTIPLE_DUPLICATES_FOUND_ERROR, BaseConfigurationResource, FtdInvalidOperationNameError, QueryParams
+        MULTIPLE_DUPLICATES_FOUND_ERROR, BaseConfigurationResource, FtdInvalidOperationNameError, QueryParams, \
+        ADD_OPERATION_NOT_SUPPORTED_ERROR, ParamName
     from ansible.module_utils.fdm_swagger_client import ValidationError
 except ImportError:
     from module_utils.common import FtdServerError, HTTPMethod, ResponseParams, FtdConfigurationError
     from module_utils.configuration import DUPLICATE_NAME_ERROR_MESSAGE, UNPROCESSABLE_ENTITY_STATUS, \
-        MULTIPLE_DUPLICATES_FOUND_ERROR, BaseConfigurationResource, FtdInvalidOperationNameError, QueryParams
+        MULTIPLE_DUPLICATES_FOUND_ERROR, BaseConfigurationResource, FtdInvalidOperationNameError, QueryParams, \
+        ADD_OPERATION_NOT_SUPPORTED_ERROR, ParamName
     from module_utils.fdm_swagger_client import ValidationError
 
 ADD_RESPONSE = {'status': 'Object added'}
@@ -47,11 +49,7 @@ class TestUpsertOperationUnitTests(unittest.TestCase):
 
         assert operation_a == self._resource._get_operation_name(checker_wrapper(operation_a), operations)
         assert operation_b == self._resource._get_operation_name(checker_wrapper(operation_b), operations)
-
-        self.assertRaises(
-            FtdConfigurationError,
-            self._resource._get_operation_name, checker_wrapper(None), operations
-        )
+        assert self._resource._get_operation_name(checker_wrapper(None), operations) is None
 
     @mock.patch.object(BaseConfigurationResource, "_get_operation_name")
     @mock.patch.object(BaseConfigurationResource, "add_object")
@@ -66,6 +64,19 @@ class TestUpsertOperationUnitTests(unittest.TestCase):
             self._resource._operation_checker.is_add_operation,
             model_operations)
         add_object_mock.assert_called_once_with(add_op_name, params)
+
+    @mock.patch.object(BaseConfigurationResource, "_get_operation_name")
+    @mock.patch.object(BaseConfigurationResource, "add_object")
+    def test_add_upserted_object_with_no_add_operation(self, add_object_mock, get_operation_mock):
+        model_operations = mock.MagicMock()
+        get_operation_mock.return_value = None
+
+        with pytest.raises(FtdConfigurationError) as exc_info:
+            self._resource._add_upserted_object(model_operations, mock.MagicMock())
+            assert ADD_OPERATION_NOT_SUPPORTED_ERROR in str(exc_info.value)
+
+        get_operation_mock.assert_called_once_with(self._resource._operation_checker.is_add_operation, model_operations)
+        add_object_mock.assert_not_called()
 
     @mock.patch.object(BaseConfigurationResource, "_get_operation_name")
     @mock.patch.object(BaseConfigurationResource, "edit_object")
@@ -102,15 +113,17 @@ class TestUpsertOperationUnitTests(unittest.TestCase):
 
     @mock.patch("module_utils.configuration.OperationChecker.is_upsert_operation_supported")
     @mock.patch.object(BaseConfigurationResource, "get_operation_specs_by_model_name")
+    @mock.patch.object(BaseConfigurationResource, "_find_object_matching_params")
     @mock.patch.object(BaseConfigurationResource, "_add_upserted_object")
     @mock.patch.object(BaseConfigurationResource, "_edit_upserted_object")
     @mock.patch("module_utils.configuration._extract_model_from_upsert_operation")
-    def test_upsert_object_succesfully_added(self, extract_model_mock, edit_mock, add_mock, get_operation_mock,
-                                             is_upsert_supported_mock):
+    def test_upsert_object_successfully_added(self, extract_model_mock, edit_mock, add_mock, find_object,
+                                              get_operation_mock, is_upsert_supported_mock):
         op_name = mock.MagicMock()
         params = mock.MagicMock()
 
         is_upsert_supported_mock.return_value = True
+        find_object.return_value = None
 
         result = self._resource.upsert_object(op_name, params)
 
@@ -118,24 +131,26 @@ class TestUpsertOperationUnitTests(unittest.TestCase):
         is_upsert_supported_mock.assert_called_once_with(get_operation_mock.return_value)
         extract_model_mock.assert_called_once_with(op_name)
         get_operation_mock.assert_called_once_with(extract_model_mock.return_value)
+        find_object.assert_called_once_with(extract_model_mock.return_value, params)
         add_mock.assert_called_once_with(get_operation_mock.return_value, params)
         edit_mock.assert_not_called()
 
+    @mock.patch("module_utils.configuration.equal_objects")
     @mock.patch("module_utils.configuration.OperationChecker.is_upsert_operation_supported")
     @mock.patch.object(BaseConfigurationResource, "get_operation_specs_by_model_name")
+    @mock.patch.object(BaseConfigurationResource, "_find_object_matching_params")
     @mock.patch.object(BaseConfigurationResource, "_add_upserted_object")
     @mock.patch.object(BaseConfigurationResource, "_edit_upserted_object")
     @mock.patch("module_utils.configuration._extract_model_from_upsert_operation")
-    def test_upsert_object_succesfully_edited(self, extract_model_mock, edit_mock, add_mock, get_operation_mock,
-                                              is_upsert_supported_mock):
+    def test_upsert_object_successfully_edited(self, extract_model_mock, edit_mock, add_mock, find_object,
+                                               get_operation_mock, is_upsert_supported_mock, equal_objects_mock):
         op_name = mock.MagicMock()
         params = mock.MagicMock()
+        existing_obj = mock.MagicMock()
 
         is_upsert_supported_mock.return_value = True
-        error = FtdConfigurationError("Obj duplication error")
-        error.obj = mock.MagicMock()
-
-        add_mock.side_effect = error
+        find_object.return_value = existing_obj
+        equal_objects_mock.return_value = False
 
         result = self._resource.upsert_object(op_name, params)
 
@@ -143,16 +158,46 @@ class TestUpsertOperationUnitTests(unittest.TestCase):
         extract_model_mock.assert_called_once_with(op_name)
         get_operation_mock.assert_called_once_with(extract_model_mock.return_value)
         is_upsert_supported_mock.assert_called_once_with(get_operation_mock.return_value)
-        add_mock.assert_called_once_with(get_operation_mock.return_value, params)
-        edit_mock.assert_called_once_with(get_operation_mock.return_value, error.obj, params)
+        add_mock.assert_not_called()
+        equal_objects_mock.assert_called_once_with(existing_obj, params[ParamName.DATA])
+        edit_mock.assert_called_once_with(get_operation_mock.return_value, existing_obj, params)\
 
+
+    @mock.patch("module_utils.configuration.equal_objects")
     @mock.patch("module_utils.configuration.OperationChecker.is_upsert_operation_supported")
     @mock.patch.object(BaseConfigurationResource, "get_operation_specs_by_model_name")
+    @mock.patch.object(BaseConfigurationResource, "_find_object_matching_params")
     @mock.patch.object(BaseConfigurationResource, "_add_upserted_object")
     @mock.patch.object(BaseConfigurationResource, "_edit_upserted_object")
     @mock.patch("module_utils.configuration._extract_model_from_upsert_operation")
-    def test_upsert_object_not_supported(self, extract_model_mock, edit_mock, add_mock, get_operation_mock,
-                                         is_upsert_supported_mock):
+    def test_upsert_object_returned_without_modifications(self, extract_model_mock, edit_mock, add_mock, find_object,
+                                                          get_operation_mock, is_upsert_supported_mock, equal_objects_mock):
+        op_name = mock.MagicMock()
+        params = mock.MagicMock()
+        existing_obj = mock.MagicMock()
+
+        is_upsert_supported_mock.return_value = True
+        find_object.return_value = existing_obj
+        equal_objects_mock.return_value = True
+
+        result = self._resource.upsert_object(op_name, params)
+
+        assert result == existing_obj
+        extract_model_mock.assert_called_once_with(op_name)
+        get_operation_mock.assert_called_once_with(extract_model_mock.return_value)
+        is_upsert_supported_mock.assert_called_once_with(get_operation_mock.return_value)
+        add_mock.assert_not_called()
+        equal_objects_mock.assert_called_once_with(existing_obj, params[ParamName.DATA])
+        edit_mock.assert_not_called()
+
+    @mock.patch("module_utils.configuration.OperationChecker.is_upsert_operation_supported")
+    @mock.patch.object(BaseConfigurationResource, "get_operation_specs_by_model_name")
+    @mock.patch.object(BaseConfigurationResource, "_find_object_matching_params")
+    @mock.patch.object(BaseConfigurationResource, "_add_upserted_object")
+    @mock.patch.object(BaseConfigurationResource, "_edit_upserted_object")
+    @mock.patch("module_utils.configuration._extract_model_from_upsert_operation")
+    def test_upsert_object_not_supported(self, extract_model_mock, edit_mock, add_mock, find_object,
+                                         get_operation_mock, is_upsert_supported_mock):
         op_name = mock.MagicMock()
         params = mock.MagicMock()
 
@@ -166,24 +211,26 @@ class TestUpsertOperationUnitTests(unittest.TestCase):
         extract_model_mock.assert_called_once_with(op_name)
         get_operation_mock.assert_called_once_with(extract_model_mock.return_value)
         is_upsert_supported_mock.assert_called_once_with(get_operation_mock.return_value)
+        find_object.assert_not_called()
         add_mock.assert_not_called()
         edit_mock.assert_not_called()
 
+    @mock.patch("module_utils.configuration.equal_objects")
     @mock.patch("module_utils.configuration.OperationChecker.is_upsert_operation_supported")
     @mock.patch.object(BaseConfigurationResource, "get_operation_specs_by_model_name")
+    @mock.patch.object(BaseConfigurationResource, "_find_object_matching_params")
     @mock.patch.object(BaseConfigurationResource, "_add_upserted_object")
     @mock.patch.object(BaseConfigurationResource, "_edit_upserted_object")
     @mock.patch("module_utils.configuration._extract_model_from_upsert_operation")
-    def test_upsert_object_neither_added_nor_edited(self, extract_model_mock, edit_mock, add_mock, get_operation_mock,
-                                                    is_upsert_supported_mock):
+    def test_upsert_object_with_fatal_error_during_edit(self, extract_model_mock, edit_mock, add_mock, find_object,
+                                                        get_operation_mock, is_upsert_supported_mock, equal_objects_mock):
         op_name = mock.MagicMock()
         params = mock.MagicMock()
+        existing_obj = mock.MagicMock()
 
         is_upsert_supported_mock.return_value = True
-        error = FtdConfigurationError("Obj duplication error")
-        error.obj = mock.MagicMock()
-
-        add_mock.side_effect = error
+        find_object.return_value = existing_obj
+        equal_objects_mock.return_value = False
         edit_mock.side_effect = FtdConfigurationError("Some object edit error")
 
         self.assertRaises(
@@ -194,20 +241,23 @@ class TestUpsertOperationUnitTests(unittest.TestCase):
         is_upsert_supported_mock.assert_called_once_with(get_operation_mock.return_value)
         extract_model_mock.assert_called_once_with(op_name)
         get_operation_mock.assert_called_once_with(extract_model_mock.return_value)
-        add_mock.assert_called_once_with(get_operation_mock.return_value, params)
-        edit_mock.assert_called_once_with(get_operation_mock.return_value, error.obj, params)
+        find_object.assert_called_once_with(extract_model_mock.return_value, params)
+        add_mock.assert_not_called()
+        edit_mock.assert_called_once_with(get_operation_mock.return_value, existing_obj, params)
 
     @mock.patch("module_utils.configuration.OperationChecker.is_upsert_operation_supported")
     @mock.patch.object(BaseConfigurationResource, "get_operation_specs_by_model_name")
+    @mock.patch.object(BaseConfigurationResource, "_find_object_matching_params")
     @mock.patch.object(BaseConfigurationResource, "_add_upserted_object")
     @mock.patch.object(BaseConfigurationResource, "_edit_upserted_object")
     @mock.patch("module_utils.configuration._extract_model_from_upsert_operation")
-    def test_upsert_object_with_fatal_error_during_add(self, extract_model_mock, edit_mock, add_mock,
+    def test_upsert_object_with_fatal_error_during_add(self, extract_model_mock, edit_mock, add_mock, find_object,
                                                        get_operation_mock, is_upsert_supported_mock):
         op_name = mock.MagicMock()
         params = mock.MagicMock()
 
         is_upsert_supported_mock.return_value = True
+        find_object.return_value = None
 
         error = FtdConfigurationError("Obj duplication error")
         add_mock.side_effect = error
@@ -220,6 +270,7 @@ class TestUpsertOperationUnitTests(unittest.TestCase):
         is_upsert_supported_mock.assert_called_once_with(get_operation_mock.return_value)
         extract_model_mock.assert_called_once_with(op_name)
         get_operation_mock.assert_called_once_with(extract_model_mock.return_value)
+        find_object.assert_called_once_with(extract_model_mock.return_value, params)
         add_mock.assert_called_once_with(get_operation_mock.return_value, params)
         edit_mock.assert_not_called()
 
@@ -263,13 +314,28 @@ class TestUpsertOperationFunctionalTests(object):
         def get_operation_spec(name):
             return operations[name]
 
+        def request_handler(url_path=None, http_method=None, body_params=None, path_params=None, query_params=None):
+            if http_method == HTTPMethod.POST:
+                assert url_path == url
+                assert body_params == params['data']
+                assert query_params == {}
+                assert path_params == params['path_params']
+                return {
+                    ResponseParams.SUCCESS: True,
+                    ResponseParams.RESPONSE: ADD_RESPONSE
+                }
+            elif http_method == HTTPMethod.GET:
+                return {
+                    ResponseParams.SUCCESS: True,
+                    ResponseParams.RESPONSE: {'items': []}
+                }
+            else:
+                assert False
+
         connection_mock.get_operation_spec = get_operation_spec
 
         connection_mock.get_operation_specs_by_model_name.return_value = operations
-        connection_mock.send_request.return_value = {
-            ResponseParams.SUCCESS: True,
-            ResponseParams.RESPONSE: ADD_RESPONSE
-        }
+        connection_mock.send_request = request_handler
         params = {
             'operation': 'upsertObject',
             'data': {'id': '123', 'name': 'testObject', 'type': 'object'},
@@ -279,12 +345,48 @@ class TestUpsertOperationFunctionalTests(object):
 
         result = self._resource_execute_operation(params, connection=connection_mock)
 
-        connection_mock.send_request.assert_called_once_with(url_path=url,
-                                                             http_method=HTTPMethod.POST,
-                                                             path_params=params['path_params'],
-                                                             query_params={},
-                                                             body_params=params['data'])
         assert ADD_RESPONSE == result
+
+    def test_module_should_fail_when_no_add_operation_and_no_object(self, connection_mock):
+        url = '/test'
+
+        operations = {
+            'getObjectList': {
+                'method': HTTPMethod.GET,
+                'url': url,
+                'modelName': 'Object',
+                'returnMultipleItems': True},
+            'editObject': {
+                'method': HTTPMethod.PUT,
+                'modelName': 'Object',
+                'url': '/test/{objId}'},
+            'otherObjectOperation': {
+                'method': HTTPMethod.GET,
+                'modelName': 'Object',
+                'url': '/test/{objId}',
+                'returnMultipleItems': False
+            }}
+
+        def get_operation_spec(name):
+            return operations[name]
+
+        connection_mock.get_operation_spec = get_operation_spec
+
+        connection_mock.get_operation_specs_by_model_name.return_value = operations
+        connection_mock.send_request.return_value = {
+            ResponseParams.SUCCESS: True,
+            ResponseParams.RESPONSE: {'items': []}
+        }
+        params = {
+            'operation': 'upsertObject',
+            'data': {'id': '123', 'name': 'testObject', 'type': 'object'},
+            'path_params': {'objId': '123'},
+            'register_as': 'test_var'
+        }
+
+        with pytest.raises(FtdConfigurationError) as exc_info:
+            self._resource_execute_operation(params, connection=connection_mock)
+            assert ADD_OPERATION_NOT_SUPPORTED_ERROR in str(exc_info.value)
 
     # test when object exists but with different fields(except id)
     def test_module_should_update_object_when_upsert_operation_and_object_exists(self, connection_mock):


### PR DESCRIPTION
This PR updates `upsert` operation to support objects that do not have `add` operation and can not be added. 

### Why this change is needed?
Initially, `upsert` operation could be used for objects that have at least these 3 operations: `getList`, `add` and `edit`. Though, some objects (for example, `PhysicalInterface`) cannot be created but can be edited. Thus, we decided, that it would be nice to support `upsert` operations for noncreatable too.

### Implementation details
`upsert` operation is updated to have the following flow:
1. try to find an existing object matching given criteria;
2. if the object does not exist, we create it (or raise an exception if `add` operation is not supported);
3. if the object exists and differs from the one in the playbook, the existing object get updated;
4. if the object exists and matches the one in the playbook, nothing happens.