### PR TITLE
Add variable to skip tests on specific vFTD versions

### DIFF
--- a/samples/test_ftd_configuration_validation.yml
+++ b/samples/test_ftd_configuration_validation.yml
@@ -128,11 +128,14 @@
         register_as: "testObj"
       register: result
       ignore_errors: yes
+      # ignoring this test as API docs in v6.2.3 do not have required fields for objects;
+      tags: skip-on-6.2.3
     - assert:
         that:
           - 'result.changed == false'
           - 'result.failed == true'
           - 'result.msg == {"Invalid data provided": {"required": ["name", "subType", "type", "value"]}}'
+      tags: skip-on-6.2.3
 
     - name: data should contain valid data
       ftd_configuration:

--- a/samples/test_ftd_configuration_validation.yml
+++ b/samples/test_ftd_configuration_validation.yml
@@ -128,14 +128,13 @@
         register_as: "testObj"
       register: result
       ignore_errors: yes
-      # ignoring this test as API docs in v6.2.3 do not have required fields for objects;
-      tags: skip-on-6.2.3
+      when: ftd_version is undefined or ftd_version != '6.2.3'
     - assert:
         that:
           - 'result.changed == false'
           - 'result.failed == true'
           - 'result.msg == {"Invalid data provided": {"required": ["name", "subType", "type", "value"]}}'
-      tags: skip-on-6.2.3
+      when: ftd_version is undefined or ftd_version != '6.2.3'
 
     - name: data should contain valid data
       ftd_configuration:


### PR DESCRIPTION
vFTD 6.2.3 does not have required fields for objects in Swagger docs, so some tests must be skipped. We do it by adding a `--extra-vars 'ftd_version=6.2.3'` argument to specific plays.