### PR TITLE
Sample playbook for initial device setup

### DIFF
--- a/samples/initial_device_setup.yml
+++ b/samples/initial_device_setup.yml
@@ -1,0 +1,19 @@
+- hosts: vftd
+  connection: httpapi
+  tasks:
+    - name: Get provisioning info
+      ftd_configuration:
+        operation: getInitialProvision
+        path_params:
+          objId: default
+        register_as: provisionInfo
+
+    - name: Complete initial provisioning
+      ftd_configuration:
+        operation: addInitialProvision
+        data:
+          acceptEULA: True
+          eulaText: "{{ provisionInfo['eulaText'] }}"
+          currentPassword: "oldPassword"
+          newPassword: "newPassword1$"
+          type: initialprovision

--- a/samples/initial_device_setup.yml
+++ b/samples/initial_device_setup.yml
@@ -14,7 +14,7 @@
 
     - name: Confirm EULA acceptance
       pause:
-        prompt: 'Please confirm you want to accept EULA. Press return to continue. To about, press Ctrl+C and then "A"'
+        prompt: 'Please confirm you want to accept EULA. Press Return to continue. To abort, press Ctrl+C and then "A"'
 
     - name: Complete initial provisioning
       ftd_configuration:

--- a/samples/initial_device_setup.yml
+++ b/samples/initial_device_setup.yml
@@ -8,6 +8,14 @@
           objId: default
         register_as: provisionInfo
 
+    - name: Show EULA text
+      debug:
+        msg: "EULA details: {{ provisionInfo['eulaText'] }}"
+
+    - name: Confirm EULA acceptance
+      pause:
+        prompt: 'Please confirm you want to accept EULA. Press return to continue. To about, press Ctrl+C and then "A"'
+
     - name: Complete initial provisioning
       ftd_configuration:
         operation: addInitialProvision


### PR DESCRIPTION
### Overview
This sample playbook makes an initial setup of the device: accepts EULA, changes password and enables license evaluation mode.
### Why
When FTD is freshly installed from the image, its REST API cannot be used immediately, because the device is locked. 
![screen shot 2019-02-05 at 5 09 14 pm](https://user-images.githubusercontent.com/4347159/52282511-3fc9b780-2969-11e9-9c3f-6e2cad2dfec3.png)
To start using the API, the device should be unlocked using Provision API. This sample shows how to do it.