### PR TITLE
Add API backward compatibility disclaimer

### DIFF
--- a/docs/build.py
+++ b/docs/build.py
@@ -172,7 +172,7 @@ def _generate_ansible_docs(args, api_spec, template_ctx):
         .generate_doc_files(args.dist, args.models)
     generator.ModuleDocGenerator(DEFAULT_TEMPLATE_DIR, template_ctx, DEFAULT_MODULE_DIR)\
         .generate_doc_files(args.dist)
-    generator.StaticDocGenerator(STATIC_TEMPLATE_DIR, template_ctx)\
+    generator.StaticDocGenerator(DEFAULT_TEMPLATE_DIR, template_ctx, STATIC_TEMPLATE_DIR)\
         .generate_doc_files(args.dist)
 
 

--- a/docs/generator.py
+++ b/docs/generator.py
@@ -296,16 +296,17 @@ class StaticDocGenerator(BaseDocGenerator):
     Documentation is written using Markdown markup language.
     """
 
-    def __init__(self, template_dir, template_ctx):
+    def __init__(self, template_dir, template_ctx, static_template_dir):
         super().__init__(template_dir, template_ctx)
-        self._template_dir = template_dir
+        self._jinja_env.loader = FileSystemLoader([template_dir, static_template_dir])
+        self._static_template_dir = static_template_dir
 
     def generate_doc_files(self, dest_dir):
-        for filename in os.listdir(self._template_dir):
+        for filename in os.listdir(self._static_template_dir):
             if filename.endswith(self.J2_SUFFIX):
                 self._generate_from_template(dest_dir, filename)
             else:
-                copyfile(os.path.join(self._template_dir, filename), os.path.join(dest_dir, filename))
+                copyfile(os.path.join(self._static_template_dir, filename), os.path.join(dest_dir, filename))
 
     def _generate_from_template(self, dest_dir, filename):
         template = self._jinja_env.get_template(filename)

--- a/docs/templates/includes/api_compatibility_disclaimer.j2
+++ b/docs/templates/includes/api_compatibility_disclaimer.j2
@@ -1,0 +1,1 @@
+__NOTE__: _Cisco makes no guarantee that the API version included on this Firepower Threat Device (the “API”) will be compatible with future releases. Cisco, at any time in its sole discretion, may modify, enhance or otherwise improve the API based on user feedback._

--- a/docs/templates/intro.md.j2
+++ b/docs/templates/intro.md.j2
@@ -4,6 +4,8 @@
 
 You can use a REST API to programmatically interact with a Firepower Threat Defense device that you are managing locally through Firepower Device Manager.
 
+__NOTE__: _Cisco makes no guarantee that the API version included on this Firepower Threat Device (the “API”) will be compatible with future releases. Cisco, at any time in its sole discretion, may modify, enhance or otherwise improve the API based on user feedback._
+
 ## Audience for This Programming Guide
 
 This guide is written on the assumption that you have a general knowledge of programming and a specific understanding of REST APIs and JSON. If you are new to these technologies, please first read a general guide on REST APIs.

--- a/docs/templates/intro.md.j2
+++ b/docs/templates/intro.md.j2
@@ -4,7 +4,7 @@
 
 You can use a REST API to programmatically interact with a Firepower Threat Defense device that you are managing locally through Firepower Device Manager.
 
-__NOTE__: _Cisco makes no guarantee that the API version included on this Firepower Threat Device (the “API”) will be compatible with future releases. Cisco, at any time in its sole discretion, may modify, enhance or otherwise improve the API based on user feedback._
+{% include 'includes/api_compatibility_disclaimer.j2' %}
 
 ## Audience for This Programming Guide
 

--- a/docs/templates/static/intro.md.j2
+++ b/docs/templates/static/intro.md.j2
@@ -10,7 +10,7 @@ Cisco Firepower Threat Defense (FTD) devices. Currently, three Ansible modules a
 FTD modules allow executing any API operations in form of Ansible plays. The modules configure virtual and 
 physical devices by sending HTTPS calls formatted according to the REST API specification.
 
-__NOTE__: _Cisco makes no guarantee that the API version included on this Firepower Threat Device (the “API”) will be compatible with future releases. Cisco, at any time in its sole discretion, may modify, enhance or otherwise improve the API based on user feedback._
+{% include 'includes/api_compatibility_disclaimer.j2' %}
 
 ### How to use Ansible modules
 

--- a/docs/templates/static/intro.md.j2
+++ b/docs/templates/static/intro.md.j2
@@ -10,6 +10,10 @@ Cisco Firepower Threat Defense (FTD) devices. Currently, three Ansible modules a
 FTD modules allow executing any API operations in form of Ansible plays. The modules configure virtual and 
 physical devices by sending HTTPS calls formatted according to the REST API specification.
 
+__NOTE__: _Cisco makes no guarantee that the API version included on this Firepower Threat Device (the “API”) will be compatible with future releases. Cisco, at any time in its sole discretion, may modify, enhance or otherwise improve the API based on user feedback._
+
+### How to use Ansible modules
+
 A simple example of creating a network with the [`ftd_configuration`](modules/ftd_configuration.md) module looks like this:
 
 ```yaml
@@ -25,3 +29,5 @@ A simple example of creating a network with the [`ftd_configuration`](modules/ft
              value: "0.0.0.0/0"
              type: "networkobject"
  ```
+ 
+ Check out the [Examples](examples.md) section for more playbook samples. 


### PR DESCRIPTION
Adding a note about API backward compatibility to the docs:

_Cisco makes no guarantee that the API version included on this Firepower Threat Device (the “API”) will be compatible with future releases. Cisco, at any time in its sole discretion, may modify, enhance or otherwise improve the API based on user feedback._
