### PR TITLE
Change order for file loader in StaticDocGenerator

### DIFF
--- a/docs/generator.py
+++ b/docs/generator.py
@@ -298,7 +298,7 @@ class StaticDocGenerator(BaseDocGenerator):
 
     def __init__(self, template_dir, template_ctx, static_template_dir):
         super().__init__(template_dir, template_ctx)
-        self._jinja_env.loader = FileSystemLoader([template_dir, static_template_dir])
+        self._jinja_env.loader = FileSystemLoader([static_template_dir, template_dir])
         self._static_template_dir = static_template_dir
 
     def generate_doc_files(self, dest_dir):


### PR DESCRIPTION
We have `intro.md.j2` files both in the root folder (for Ansible docs) and the `static` folder (for API docs). `StaticDocGenerator` chose the wrong one by mistake. This PR updates `FileSystemLoader` to check `static` folder first, and then the root folder.