### PR TITLE
Skip Kick-related unit tests when Kick is not installed

### DIFF
--- a/library/ftd_install.py
+++ b/library/ftd_install.py
@@ -265,8 +265,8 @@ def main():
 def check_required_params_for_local_connection(module, params):
     missing_params = [k for k, v in iteritems(params) if k in REQUIRED_PARAMS_FOR_LOCAL_CONNECTION and v is None]
     if missing_params:
-        message = "The following parameters are mandatory when the module is used with 'local' connection: %s." % ', '.join(
-            sorted(missing_params))
+        message = "The following parameters are mandatory when the module is used with 'local' connection: %s." %\
+                  ', '.join(sorted(missing_params))
         module.fail_json(msg=message)
 
 

--- a/library/ftd_install.py
+++ b/library/ftd_install.py
@@ -195,18 +195,11 @@ from enum import Enum
 from six import iteritems
 
 try:
-    import kick  # noqa: F401
-
-    HAS_KICK = True
-except ImportError:
-    HAS_KICK = False
-
-try:
     from ansible.module_utils.configuration import BaseConfigurationResource, ParamName, PATH_PARAMS_FOR_DEFAULT_OBJ
-    from ansible.module_utils.device import FtdPlatformFactory, FtdModel
+    from ansible.module_utils.device import HAS_KICK, FtdPlatformFactory, FtdModel
 except ImportError:
     from module_utils.configuration import BaseConfigurationResource, ParamName, PATH_PARAMS_FOR_DEFAULT_OBJ
-    from module_utils.device import FtdPlatformFactory, FtdModel
+    from module_utils.device import HAS_KICK, FtdPlatformFactory, FtdModel
 
 REQUIRED_PARAMS_FOR_LOCAL_CONNECTION = ['device_ip', 'device_netmask', 'device_gateway', 'device_model', 'dns_server']
 
@@ -272,8 +265,8 @@ def main():
 def check_required_params_for_local_connection(module, params):
     missing_params = [k for k, v in iteritems(params) if k in REQUIRED_PARAMS_FOR_LOCAL_CONNECTION and v is None]
     if missing_params:
-        message = "The following parameters are mandatory when the module is used with 'local' connection: %s." \
-                  % ', '.join(missing_params)
+        message = "The following parameters are mandatory when the module is used with 'local' connection: %s." % ', '.join(
+            sorted(missing_params))
         module.fail_json(msg=message)
 
 

--- a/module_utils/device.py
+++ b/module_utils/device.py
@@ -1,7 +1,13 @@
 from enum import Enum
 
-from kick.device2.ftd5500x.actions.ftd5500x import Ftd5500x
-from kick.device2.kp.actions import Kp
+try:
+    from kick.device2.ftd5500x.actions.ftd5500x import Ftd5500x
+    from kick.device2.kp.actions import Kp
+    from kick.device2.ssp.actions import Ssp
+
+    HAS_KICK = True
+except ImportError:
+    HAS_KICK = False
 
 
 class FtdModel(Enum):

--- a/module_utils/device.py
+++ b/module_utils/device.py
@@ -3,7 +3,6 @@ from enum import Enum
 try:
     from kick.device2.ftd5500x.actions.ftd5500x import Ftd5500x
     from kick.device2.kp.actions import Kp
-    from kick.device2.ssp.actions import Ssp
 
     HAS_KICK = True
 except ImportError:

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,5 @@ urllib3==1.23
 lxml==4.3.0
 --extra-index-url http://kick-pypi.cisco.com/kick/prod/
 --trusted-host kick-pypi.cisco.com
-kick
+# kick library depends on unicon that is available for specific Pythons: https://pypi.org/project/unicon/#files
+kick ; python_version >= '3.4' and python_version <= '3.6' and platform_python_implementation == 'CPython'

--- a/test/unit/module_utils/test_device.py
+++ b/test/unit/module_utils/test_device.py
@@ -66,11 +66,11 @@ class TestFtd2100Platform(object):
         ftd = FtdPlatformFactory.create(FtdModel.FTD_2110.value, module_params)
         ftd.install_ftd_image(module_params)
 
-        kp_mock.assert_called_once()
-        kp_mock.return_value.ssh_console.assert_called_once()
+        assert kp_mock.called
+        assert kp_mock.return_value.ssh_console.called
         ftd_line = kp_mock.return_value.ssh_console.return_value
-        ftd_line.baseline_fp2k_ftd.assert_called_once()
-        ftd_line.disconnect.assert_called_once()
+        assert ftd_line.baseline_fp2k_ftd.called
+        assert ftd_line.disconnect.called
 
     def test_install_ftd_image_should_call_disconnect_when_install_fails(self, kp_mock, module_params):
         ftd_line = kp_mock.return_value.ssh_console.return_value
@@ -80,8 +80,8 @@ class TestFtd2100Platform(object):
         with pytest.raises(Exception):
             ftd.install_ftd_image(module_params)
 
-        ftd_line.baseline_fp2k_ftd.assert_called_once()
-        ftd_line.disconnect.assert_called_once()
+        assert ftd_line.baseline_fp2k_ftd.called
+        assert ftd_line.disconnect.called
 
 
 class TestFtdAsa5500xPlatform(object):
@@ -98,11 +98,11 @@ class TestFtdAsa5500xPlatform(object):
         ftd = FtdPlatformFactory.create(FtdModel.FTD_ASA5508_X.value, module_params)
         ftd.install_ftd_image(module_params)
 
-        asa5500x_mock.assert_called_once()
-        asa5500x_mock.return_value.ssh_console.assert_called_once()
+        assert asa5500x_mock.called
+        assert asa5500x_mock.return_value.ssh_console.called
         ftd_line = asa5500x_mock.return_value.ssh_console.return_value
-        ftd_line.rommon_to_new_image.assert_called_once()
-        ftd_line.disconnect.assert_called_once()
+        assert ftd_line.rommon_to_new_image.called
+        assert ftd_line.disconnect.called
 
     def test_install_ftd_image_should_call_disconnect_when_install_fails(self, asa5500x_mock, module_params):
         ftd_line = asa5500x_mock.return_value.ssh_console.return_value
@@ -112,5 +112,5 @@ class TestFtdAsa5500xPlatform(object):
         with pytest.raises(Exception):
             ftd.install_ftd_image(module_params)
 
-        ftd_line.rommon_to_new_image.assert_called_once()
-        ftd_line.disconnect.assert_called_once()
+        assert ftd_line.rommon_to_new_image.called
+        assert ftd_line.disconnect.called

--- a/test/unit/module_utils/test_device.py
+++ b/test/unit/module_utils/test_device.py
@@ -1,5 +1,7 @@
 import pytest
 
+pytest.importorskip("kick")
+
 from module_utils.device import FtdPlatformFactory, FtdModel, FtdAsa5500xPlatform, Ftd2100Platform, AbstractFtdPlatform
 from test.unit.test_ftd_install import DEFAULT_MODULE_PARAMS
 
@@ -16,6 +18,11 @@ class TestFtdModel(object):
 
 
 class TestFtdPlatformFactory(object):
+
+    @pytest.fixture(autouse=True)
+    def mock_devices(self, mocker):
+        mocker.patch('module_utils.device.Kp')
+        mocker.patch('module_utils.device.Ftd5500x')
 
     def test_factory_should_return_corresponding_platform(self):
         ftd_platform = FtdPlatformFactory.create(FtdModel.FTD_ASA5508_X.value, dict(DEFAULT_MODULE_PARAMS))

--- a/test/unit/test_ftd_install.py
+++ b/test/unit/test_ftd_install.py
@@ -1,11 +1,8 @@
 from __future__ import absolute_import
 
-import sys
-
 import pytest
 from ansible.compat.tests.mock import PropertyMock
 from ansible.module_utils import basic
-from six.moves import reload_module
 from units.modules.utils import set_module_args, exit_json, fail_json, AnsibleFailJson, AnsibleExitJson
 
 from library import ftd_install
@@ -15,6 +12,7 @@ DEFAULT_MODULE_PARAMS = dict(
     device_hostname="firepower",
     device_username="admin",
     device_password="pass",
+    device_new_password="new_pass",
     device_sudo_password="sudopass",
     device_ip="192.168.0.1",
     device_netmask="255.255.255.0",
@@ -57,9 +55,12 @@ class TestFtdInstall(object):
     def ftd_factory_mock(self, mocker):
         return mocker.patch('library.ftd_install.FtdPlatformFactory')
 
+    @pytest.fixture(autouse=True)
+    def has_kick_mock(self, mocker):
+        return mocker.patch('library.ftd_install.HAS_KICK', True)
+
     def test_module_should_fail_when_kick_is_not_installed(self, mocker):
-        mocker.patch.dict(sys.modules, {'kick': None})
-        reload_module(ftd_install)
+        mocker.patch('library.ftd_install.HAS_KICK', False)
 
         set_module_args(dict(DEFAULT_MODULE_PARAMS))
         with pytest.raises(AnsibleFailJson) as ex:
@@ -68,9 +69,6 @@ class TestFtdInstall(object):
         result = ex.value.args[0]
         assert result['failed']
         assert result['msg'] == "Kick Python module is required to run this module."
-
-        mocker.stopall()
-        reload_module(ftd_install)
 
     def test_module_should_fail_when_platform_is_not_supported(self, config_resource_mock):
         config_resource_mock.execute_operation.return_value = {'platformModel': 'nonSupportedModel'}
@@ -114,7 +112,7 @@ class TestFtdInstall(object):
         result = ex.value.args[0]
         assert result['failed']
         expected_msg = "The following parameters are mandatory when the module is used with 'local' connection: " \
-                       "device_ip, device_netmask, device_gateway."
+                       "device_gateway, device_ip, device_netmask."
         assert expected_msg == result['msg']
 
     def test_module_should_return_when_software_is_already_installed(self, config_resource_mock):


### PR DESCRIPTION
## Overview
Kick library depends on [unicon](https://pypi.org/project/unicon/) that is available for certain versions and distributions of Python. As our test suite runs with multiple Python versions, we should skip Kick-related unit tests when it cannot be installed.

## Implementation details
* added a constraint to `requirements.txt` so that `kick` is installed only for CPython 3.4/3.5/3.6;
* skip tests from `test_device.py` when `kick` module is not installed using `pytest.importorskip("kick")`;
* updated `ftd_install.py` not to use `kick` directly so its unit tests can be run with any Python version.