### PR TITLE
Fix filters and allow null values

### DIFF
--- a/module_utils/configuration.py
+++ b/module_utils/configuration.py
@@ -273,8 +273,6 @@ class BaseConfigurationResource(object):
         return self._models_operations_specs_cache[model_name]
 
     def get_objects_by_filter(self, operation_name, params):
-        def transform_filters_to_query_param(filter_params):
-            return ';'.join(['%s:%s' % (key, val) for key, val in sorted(iteritems(filter_params))])
 
         def match_filters(filter_params, obj):
             for k, v in iteritems(filter_params):
@@ -284,14 +282,15 @@ class BaseConfigurationResource(object):
 
         _, query_params, path_params = _get_user_params(params)
         # copy required params to avoid mutation of passed `params` dict
-        get_list_params = {ParamName.QUERY_PARAMS: dict(query_params), ParamName.PATH_PARAMS: dict(path_params)}
+        url_params = {ParamName.QUERY_PARAMS: dict(query_params), ParamName.PATH_PARAMS: dict(path_params)}
 
         filters = params.get(ParamName.FILTERS) or {}
-        if filters:
-            get_list_params[ParamName.QUERY_PARAMS][QueryParams.FILTER] = transform_filters_to_query_param(filters)
+        if QueryParams.FILTER not in url_params[ParamName.QUERY_PARAMS] and 'name' in filters:
+            # most endpoints only support filtering by name, so remaining `filters` are applied on returned objects
+            url_params[ParamName.QUERY_PARAMS][QueryParams.FILTER] = 'name:%s' % filters['name']
 
         item_generator = iterate_over_pageable_resource(
-            partial(self.send_general_request, operation_name=operation_name), get_list_params
+            partial(self.send_general_request, operation_name=operation_name), url_params
         )
         return (i for i in item_generator if match_filters(filters, i))
 

--- a/test/unit/module_utils/test_configuration.py
+++ b/test/unit/module_utils/test_configuration.py
@@ -85,12 +85,11 @@ class TestBaseConfigurationResource(object):
         # we need evaluate it.
         assert [objects[1]] == list(resource.get_objects_by_filter(
             'test',
-            {ParamName.FILTERS: {'type': 1, 'foo': {'bar': 'buz'}}}))
+            {ParamName.FILTERS: {'name': 'obj2', 'type': 1, 'foo': {'bar': 'buz'}}}))
 
         send_request_mock.assert_has_calls(
             [
-                mock.call('/object/', 'get', {}, {},
-                          {QueryParams.FILTER: "foo:{'bar': 'buz'};type:1", 'limit': 10, 'offset': 0})
+                mock.call('/object/', 'get', {}, {}, {QueryParams.FILTER: 'name:obj2', 'limit': 10, 'offset': 0})
             ]
         )
 
@@ -116,8 +115,7 @@ class TestBaseConfigurationResource(object):
             {ParamName.FILTERS: {'type': 'foo'}}))
         send_request_mock.assert_has_calls(
             [
-                mock.call('/object/', 'get', {}, {},
-                          {QueryParams.FILTER: "type:foo", 'limit': 10, 'offset': 0})
+                mock.call('/object/', 'get', {}, {}, {'limit': 10, 'offset': 0})
             ]
         )
 
@@ -141,10 +139,8 @@ class TestBaseConfigurationResource(object):
         assert [{'name': 'obj1', 'type': 'foo'}, {'name': 'obj3', 'type': 'foo'}] == resp
         send_request_mock.assert_has_calls(
             [
-                mock.call('/object/', 'get', {}, {},
-                          {QueryParams.FILTER: "type:foo", 'limit': 2, 'offset': 0}),
-                mock.call('/object/', 'get', {}, {},
-                          {QueryParams.FILTER: "type:foo", 'limit': 2, 'offset': 2})
+                mock.call('/object/', 'get', {}, {}, {'limit': 2, 'offset': 0}),
+                mock.call('/object/', 'get', {}, {}, {'limit': 2, 'offset': 2})
             ]
         )
 

--- a/test/unit/module_utils/test_fdm_swagger_validator.py
+++ b/test/unit/module_utils/test_fdm_swagger_validator.py
@@ -416,6 +416,29 @@ class TestFdmSwaggerValidator(unittest.TestCase):
             ]
         }) == sort_validator_rez(rez)
 
+        data = {
+            'objId': "123",
+            'parentId': "1",
+            'someParam': None,
+            'p_integer': None
+        }
+        valid, rez = getattr(validator, method)('getNetwork', data)
+        assert not valid
+        assert sort_validator_rez({
+            'invalid_type': [
+                {
+                    'path': 'someParam',
+                    'expected_type': 'string',
+                    'actually_value': None
+                },
+                {
+                    'path': 'p_integer',
+                    'expected_type': 'integer',
+                    'actually_value': None
+                }
+            ]
+        }) == sort_validator_rez(rez)
+
     def test_validate_path_params_method_with_empty_data(self):
         self.validate_url_data_with_empty_data(method='validate_path_params', parameters_type='path')
 
@@ -596,6 +619,16 @@ class TestFdmSwaggerValidator(unittest.TestCase):
         assert valid
         assert rez is None
 
+    def test_pass_only_required_fields_with_none_values(self):
+        data = {
+            'subType': 'NETWORK',
+            'type': 'networkobject',
+            'value': None
+        }
+        valid, rez = FdmSwaggerValidator(mock_data).validate_data('getNetworkObjectList', data)
+        assert not valid
+        assert {'required': ['value']} == rez
+
     def test_pass_no_data_with_no_required_fields(self):
         spec = copy.deepcopy(mock_data)
         del spec['models']['NetworkObject']['required']
@@ -722,6 +755,17 @@ class TestFdmSwaggerValidator(unittest.TestCase):
             "f_number": 100,
             "f_boolean": True,
             "f_integer": 2
+        }
+
+        valid, rez = FdmSwaggerValidator(local_mock_data).validate_data('getdata', valid_data)
+        assert valid
+        assert rez is None
+
+        valid_data = {
+            "f_string": None,
+            "f_number": None,
+            "f_boolean": None,
+            "f_integer": None
         }
 
         valid, rez = FdmSwaggerValidator(local_mock_data).validate_data('getdata', valid_data)


### PR DESCRIPTION
This PR fixes the following problems with Ansible modules:
- We used to send all filters as inside `query_params`, but the back-end does not support them. Now, only `name` filter is sent as a part of `query_params`, other filters are applied after the results are fetched;
- Validation logic didn't allow to pass `None`/`null` values as a value for the field/object/array. This PR updated the validation and allows it.