### PR TITLE
add auto detection of the best api version for documentation generation

### DIFF
--- a/docs/build.py
+++ b/docs/build.py
@@ -80,8 +80,10 @@ class FtdApiClient(object):
             token_url = self._hostname + self.TOKEN_PATH_TEMPLATE.format(version)
             try:
                 token = request_token(token_url)
-            except Exception:
+            except urllib_error.HTTPError as e:
                 logger.debug("Can't get token for API version: %s", version, exc_info=True)
+                if e.code != HTTPStatus.UNAUTHORIZED:
+                    raise
             else:
                 return token
 

--- a/docs/build.py
+++ b/docs/build.py
@@ -49,7 +49,7 @@ class FtdApiClient(object):
 
     def _fetch_api_versions(self):
         try:
-            # In case of 6.2.3 when Api Versions resource does not exists HTTP 401 will be raised
+            # In case of 6.2.3 when Api Versions resource does not exists HTTP 401 will be returned
             resp = open_url(
                 self._hostname + self.API_VERSIONS_PATH,
                 method=HTTPMethod.GET,
@@ -220,7 +220,9 @@ def _generate_docs(args, api_client):
     api_spec, ftd_version = _fetch_api_spec_and_version(api_client, args)
 
     template_ctx = dict(ftd_version=ftd_version,
-                        sample_dir=DEFAULT_SAMPLES_DIR, doctype=args.doctype, base_path=api_client.base_path)
+                        sample_dir=DEFAULT_SAMPLES_DIR,
+                        doctype=args.doctype,
+                        base_path=api_client.base_path)
 
     if args.doctype == DocType.ftd_ansible:
         _generate_ansible_docs(args, api_spec, template_ctx)

--- a/docs/templates/auth.md.j2
+++ b/docs/templates/auth.md.j2
@@ -49,7 +49,7 @@ Specify the **admin** username and the correct password, for example:
 }
 ```
 #### Step 2
-Use POST https://<i>server</i>/api/fdm/{{ api_version }}/fdm/token to obtain the access token.
+Use POST https://<i>server</i>{{ base_path }}/fdm/token to obtain the access token.
 
 For example, the **curl** command would look like the following:
 
@@ -61,7 +61,7 @@ curl -X POST \
         "grant_type": "password", 
         "username": "admin", 
         "password": "Admin123" 
-    }' https://ftd.example.com/api/fdm/{{ api_version }}/fdm/token
+    }' https://ftd.example.com{{ base_path }}/fdm/token
 ```
 
 #### Step 3
@@ -131,7 +131,7 @@ For example, the following requests a custom token for api-client that expires i
 
 #### Step 2
 
-Use POST https://<i>server</i>/api/fdm/{{ api_version }}/fdm/token to obtain the access token.
+Use POST https://<i>server</i>{{ base_path }}/fdm/token to obtain the access token.
 
 For example, the **curl** command would look like the following:
 ```bash
@@ -145,7 +145,7 @@ curl -X POST \
     "desired_refresh_expires_in": 3000, 
     "desired_subject": "api-client", 
     "desired_refresh_count": 3  
-  }' https://ftd.example.com/api/fdm/{{ api_version }}/fdm/token
+  }' https://ftd.example.com{{ base_path }}/fdm/token
 ```
 
 #### Step 3
@@ -179,7 +179,7 @@ For example, a **curl** command to perform GET /object/networks might look like 
 curl -k -X GET \
     -H 'Accept: application/json' \
     -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.yJpYXQiOjE1MDI4MzU5OTEsInN1YiI6ImFwaS1jbGllbnQiLCJqdGkiOiJjOWIxYzdjYi04MjA4LTExZTctYTgxYy02YmY0NzY3ZmRmZGUiLCJuYmYiOjE1MDI4MzU5OTEsImV4cCI6MTUwMjgzODM5MSwicmVmcmVzaFRva2VuRXhwaXJlc0F0IjoxNTAyODM4OTkxMzMxLCJ0b2tlblR5cGUiOiJKV1RfQWNjZXNzIiwib3JpZ2luIjoiY3VzdG9tIn0.9IVzLjGffVQffHAWdrNkrYfvuO6TgpJ7Zi_z3RYubN8' \  
-    https://ftd.example.com/api/fdm/{{ api_version }}/object/networks
+    https://ftd.example.com{{ base_path }}/object/networks
 ```
 
 >**Note** When you use the API Explorer to try out methods and resources, the **curl** command shown does not include the **Authorization: Bearer** header. However, you must add this header when making calls from your API client.
@@ -210,7 +210,7 @@ For example:
 ```
 
 #### Step 2
-Use POST https://<i>server</i>/api/fdm/{{ api_version }}/fdm/token to obtain the refreshed access token.
+Use POST https://<i>server</i>{{ base_path }}/fdm/token to obtain the refreshed access token.
 
 For example, the **curl** command would look like the following:
 
@@ -221,7 +221,7 @@ curl -X POST \
     -d '{ 
        "grant_type": "refresh_token", 
        "refresh_token": "eyJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE1MDI4MzU5OTEsInN1YiI6ImFwaS1jbGllbnQiLCJqdGkiOiJjOWIxYzdjYi04MjA4LTExZTctYTgxYy02YmY0NzY3ZmRmZGUiLCJuYmYiOjE1MDI4MzU5OTEsImV4cCI6MTUwMjgzODk5MSwiYWNjZXNzVG9rZW5FeHBpcmVzQXQiOjE1MDI4MzgzOTEzMzEsInJlZnJlc2hDb3VudCI6MywidG9rZW5UeXBlIjoiSldUX1JlZnJlc2giLCJvcmlnaW4iOiJjdXN0b20ifQ.qseqjg3Uo183YvfN_77iJZELEqwpWw5AbKAqAnCIcSA" 
-     }' https://ftd.example.com/api/fdm/{{ api_version }}/fdm/token
+     }' https://ftd.example.com{{ base_path }}/fdm/token
 ```
 
 #### Step 3
@@ -282,7 +282,7 @@ For example:
 
 #### Step 2
 
-Use POST https://<i>server</i>/api/fdm/{{ api_version }}/fdm/token to revoke the access token.
+Use POST https://<i>server</i>{{ base_path }}/fdm/token to revoke the access token.
 
 For example, the **curl** command would look like the following:
 ```bash
@@ -293,7 +293,7 @@ curl -X POST \
         "grant_type": "revoke_token", 
         "access_token": "eyJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE1MDI5MDQzMjQsInN1YiI6ImFkbWluIiwianRpIjoiZTMzNGIxOWYtODJhNy0xMWU3LWE4MWMtNGQ3NzY2ZTExMzVkIiwibmJmIjoxNTAyOTA0MzI0LCJleHAiOjE1MDI5MDYxMjQsInJlZnJlc2hUb2tlbkV4cGlyZXNBdCI6MTUwMjkwNjcyNDExMiwidG9rZW5UeXBlIjoiSldUX0FjY2VzcyIsIm9yaWdpbiI6InBhc3N3b3JkIn0.OVZBT9yVZc4zxZfZiiLH4SZcFclaHyCPbZJC_Gyd5FE", 
         "custom_token_subject_to_revoke": "api-client" 
-    }' https://ftd.example.com/api/fdm/{{ api_version }}/fdm/token
+    }' https://ftd.example.com{{ base_path }}/fdm/token
 ```
 
 #### Step 3

--- a/docs/templates/deploy_config.md.j2
+++ b/docs/templates/deploy_config.md.j2
@@ -14,7 +14,7 @@ For example, the **curl** command would look like the following:
 curl -X POST \
     --header 'Content-Type: application/json' \
     --header 'Accept: application/json' \
-    https://ftd.example.com/api/fdm/{{ api_version }}/operational/deploy
+    https://ftd.example.com{{ base_path }}/operational/deploy
 ```
 
 #### Step 2
@@ -34,7 +34,7 @@ A good response (status code 200) looks like the following. Note the state.
   "endTime": -1,
   "state": "QUEUED",
   "links": {
-    "self": "https://ftd.example.com/api/fdm/{{ api_version }}/operational/deploy/a7a227fb-82ab-11e7-8186-0dc471ff0672"
+    "self": "https://ftd.example.com{{ base_path }}/operational/deploy/a7a227fb-82ab-11e7-8186-0dc471ff0672"
   }
 }
 ```
@@ -46,7 +46,7 @@ For example, the **curl** command would look like the following:
 ```bash
 curl -X GET \
     --header 'Accept: application/json' \
-    https://ftd.example.com/api/fdm/{{ api_version }}/operational/deploy/a7a227fb-82ab-11e7-8186-0dc471ff0672
+    https://ftd.example.com{{ base_path }}/operational/deploy/a7a227fb-82ab-11e7-8186-0dc471ff0672
 ```
 
 The response might look like the following. Note the state, DEPLOYED, indicates the job completed successfully. The modifiedObjects parameter lists the objects that were changed in the deployment job. In this case, there is a single change, to a network object named new-network.
@@ -65,7 +65,7 @@ The response might look like the following. Note the state, DEPLOYED, indicates 
   "endTime": 1502906010068,
   "state": "DEPLOYED",
   "links": {
-    "self": "https://ftd.example.com/api/fdm/{{ api_version }}/operational/deploy/a7a227fb-82ab-11e7-8186-0dc471ff0672"
+    "self": "https://ftd.example.com{{ base_path }}/operational/deploy/a7a227fb-82ab-11e7-8186-0dc471ff0672"
   }
 }
 ```

--- a/docs/templates/intro.md.j2
+++ b/docs/templates/intro.md.j2
@@ -43,11 +43,11 @@ The easiest way to determine the base URL for a given <span>Firepower Threat Def
 
 For example, you can do a GET /object/networks, and see something similar to the following in the returned output under Request URL:
 ```url
-https://ftd.example.com/api/fdm/{{ api_version }}/object/networks
+https://ftd.example.com{{ base_path }}/object/networks
 ```
 The server name part of the URL is the hostname or IP address of the <span>Firepower Threat Defense</span> device, and will be different for your device in place of “ftd.example.com.” In this example, you delete /object/networks from the path to get the base URL:
 ```url
-https://ftd.example.com/api/fdm/{{ api_version }}/
+https://ftd.example.com{{ base_path }}/
 ```
 All resource calls use this URL as the base for the request URL.
 

--- a/module_utils/fdm_swagger_client.py
+++ b/module_utils/fdm_swagger_client.py
@@ -173,6 +173,10 @@ class FdmSwaggerParser:
             SpecProp.MODEL_OPERATIONS: self._get_model_operations(operations)
         }
 
+    @property
+    def base_path(self):
+        return self._base_path
+
     def _get_model_operations(self, operations):
         model_operations = {}
         for operations_name, params in iteritems(operations):


### PR DESCRIPTION
At the moment part of the API documentation using "latest" API version while "v3" should be used.
With this patch "best API version" detection is implemented.