### PR TITLE
 Ignore reference duplicates when comparing objects

### DIFF
--- a/module_utils/common.py
+++ b/module_utils/common.py
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 #
-from copy import copy
+from collections import OrderedDict
 
 import re
 from ansible.module_utils._text import to_text
@@ -212,7 +212,9 @@ def delete_ref_duplicates(d):
 
     def delete_ref_duplicates_from_list(refs):
         if all(type(i) == dict and is_object_ref(i) for i in refs):
-            unique_reference_map = {(i['id'], i['type']): i for i in refs}
+            unique_reference_map = OrderedDict()
+            for i in refs:
+                unique_reference_map[(i['id'], i['type'])] = i
             return list(unique_reference_map.values())
         else:
             return refs

--- a/module_utils/common.py
+++ b/module_utils/common.py
@@ -220,10 +220,12 @@ def delete_ref_duplicates(d):
     if not d:
         return d
 
-    d = copy(d)
+    modified_d = {}
     for k, v in iteritems(d):
         if type(v) == list:
-            d[k] = delete_ref_duplicates_from_list(v)
+            modified_d[k] = delete_ref_duplicates_from_list(v)
         elif type(v) == dict:
-            d[k] = delete_ref_duplicates(v)
-    return d
+            modified_d[k] = delete_ref_duplicates(v)
+        else:
+            modified_d[k] = v
+    return modified_d

--- a/module_utils/common.py
+++ b/module_utils/common.py
@@ -15,11 +15,12 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 #
+from copy import copy
 
 import re
-
 from ansible.module_utils._text import to_text
 from ansible.module_utils.common.collections import is_string
+from ansible.module_utils.six import iteritems
 
 INVALID_IDENTIFIER_SYMBOLS = r'[^a-zA-Z0-9_]'
 
@@ -181,13 +182,48 @@ def equal_objects(d1, d2):
     """
     Checks whether two objects are equal. Ignores special object properties (e.g. 'id', 'version') and
     properties with None and empty values. In case properties contains a reference to the other object,
-    only object identities (ids and types) are checked.
+    only object identities (ids and types) are checked. Also, if an array field contains multiple references
+    to the same object, duplicates are ignored when comparing objects.
 
     :type d1: dict
     :type d2: dict
     :return: True if passed objects and their properties are equal. Otherwise, returns False.
     """
-    d1 = dict((k, d1[k]) for k in d1.keys() if k not in NON_COMPARABLE_PROPERTIES and d1[k])
-    d2 = dict((k, d2[k]) for k in d2.keys() if k not in NON_COMPARABLE_PROPERTIES and d2[k])
 
+    def prepare_data_for_comparison(d):
+        d = dict((k, d[k]) for k in d.keys() if k not in NON_COMPARABLE_PROPERTIES and d[k])
+        d = delete_ref_duplicates(d)
+        return d
+
+    d1 = prepare_data_for_comparison(d1)
+    d2 = prepare_data_for_comparison(d2)
     return equal_dicts(d1, d2, compare_by_reference=False)
+
+
+def delete_ref_duplicates(d):
+    """
+    Removes reference duplicates from array fields: if an array contains multiple items and some of
+    them refer to the same object, only unique references are preserved (duplicates are removed).
+
+    :param d: dict with data
+    :type d: dict
+    :return: dict without reference duplicates
+    """
+
+    def delete_ref_duplicates_from_list(refs):
+        if all(type(i) == dict and is_object_ref(i) for i in refs):
+            unique_reference_map = {(i['id'], i['type']): i for i in refs}
+            return list(unique_reference_map.values())
+        else:
+            return refs
+
+    if not d:
+        return d
+
+    d = copy(d)
+    for k, v in iteritems(d):
+        if type(v) == list:
+            d[k] = delete_ref_duplicates_from_list(v)
+        elif type(v) == dict:
+            d[k] = delete_ref_duplicates(v)
+    return d

--- a/samples/ftd_configuration/security_intelligence_url_policy.yml
+++ b/samples/ftd_configuration/security_intelligence_url_policy.yml
@@ -1,0 +1,24 @@
+- hosts: all
+  connection: httpapi
+  tasks:
+    - name: Create a Cisco URL Object
+      ftd_configuration:
+        operation: upsertURLObject
+        data:
+          name: Cisco
+          description: URL for FB
+          url: www.cisco.com
+          type: urlobject
+
+    - name: Find a Security Intelligence URL Policy
+      ftd_configuration:
+        operation: getSecurityIntelligenceURLPolicyList
+        register_as: policies
+
+    - name: Add Cisco as whitelisted URL to SecurityIntelligenceURLPolicy
+      ftd_configuration:
+        operation: upsertSecurityIntelligenceURLPolicy
+        data:
+          name: NGFW-Default-Security-Intelligence-URL-Policy
+          whitelist: '{{ policies[0]["whitelist"] + [urlobject_cisco] }}'
+          type: securityintelligenceurlpolicy

--- a/test/unit/module_utils/test_common.py
+++ b/test/unit/module_utils/test_common.py
@@ -16,7 +16,7 @@
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from module_utils.common import equal_objects
+from module_utils.common import equal_objects, delete_ref_duplicates
 
 
 # simple objects
@@ -246,3 +246,129 @@ def test_equal_objects_return_true_with_equal_nested_list_of_object_references()
             }
         }
     )
+
+
+def test_equal_objects_return_true_with_reference_list_containing_duplicates():
+    assert equal_objects(
+        {
+            'name': 'foo',
+            'config': {
+                'version': '1',
+                'ports': [{
+                    'name': 'oldPortName',
+                    'type': 'port',
+                    'id': '123'
+                }, {
+                    'name': 'oldPortName',
+                    'type': 'port',
+                    'id': '123'
+                }, {
+                    'name': 'oldPortName2',
+                    'type': 'port',
+                    'id': '234'
+                }]
+            }
+        },
+        {
+            'name': 'foo',
+            'config': {
+                'version': '1',
+                'ports': [{
+                    'name': 'newPortName',
+                    'type': 'port',
+                    'id': '123'
+                }, {
+                    'name': 'newPortName2',
+                    'type': 'port',
+                    'id': '234',
+                    'extraField': 'foo'
+                }]
+            }
+        }
+    )
+
+
+def test_delete_ref_duplicates_with_none():
+    assert delete_ref_duplicates(None) is None
+
+
+def test_delete_ref_duplicates_with_empty_dict():
+    assert {} == delete_ref_duplicates({})
+
+
+def test_delete_ref_duplicates_with_simple_object():
+    data = {
+        'id': '123',
+        'name': 'foo',
+        'type': 'bar',
+        'values': ['a', 'b']
+    }
+    assert data == delete_ref_duplicates(data)
+
+
+def test_delete_ref_duplicates_with_object_containing_refs():
+    data = {
+        'id': '123',
+        'name': 'foo',
+        'type': 'bar',
+        'refs': [
+            {'id': '123', 'type': 'baz'},
+            {'id': '234', 'type': 'baz'},
+            {'id': '234', 'type': 'foo'}
+        ]
+    }
+    assert data == delete_ref_duplicates(data)
+
+
+def test_delete_ref_duplicates_with_object_containing_duplicate_refs():
+    data = {
+        'id': '123',
+        'name': 'foo',
+        'type': 'bar',
+        'refs': [
+            {'id': '123', 'type': 'baz'},
+            {'id': '123', 'type': 'baz'},
+            {'id': '234', 'type': 'baz'},
+            {'id': '234', 'type': 'baz'},
+            {'id': '234', 'type': 'foo'}
+        ]
+    }
+    assert {
+               'id': '123',
+               'name': 'foo',
+               'type': 'bar',
+               'refs': [
+                   {'id': '123', 'type': 'baz'},
+                   {'id': '234', 'type': 'baz'},
+                   {'id': '234', 'type': 'foo'}
+               ]
+           } == delete_ref_duplicates(data)
+
+
+def test_delete_ref_duplicates_with_object_containing_duplicate_refs_in_nested_object():
+    data = {
+        'id': '123',
+        'name': 'foo',
+        'type': 'bar',
+        'children': {
+            'refs': [
+                {'id': '123', 'type': 'baz'},
+                {'id': '123', 'type': 'baz'},
+                {'id': '234', 'type': 'baz'},
+                {'id': '234', 'type': 'baz'},
+                {'id': '234', 'type': 'foo'}
+            ]
+        }
+    }
+    assert {
+               'id': '123',
+               'name': 'foo',
+               'type': 'bar',
+               'children': {
+                   'refs': [
+                       {'id': '123', 'type': 'baz'},
+                       {'id': '234', 'type': 'baz'},
+                       {'id': '234', 'type': 'foo'}
+                   ]
+               }
+           } == delete_ref_duplicates(data)

--- a/test/unit/module_utils/test_common.py
+++ b/test/unit/module_utils/test_common.py
@@ -334,15 +334,15 @@ def test_delete_ref_duplicates_with_object_containing_duplicate_refs():
         ]
     }
     assert {
-               'id': '123',
-               'name': 'foo',
-               'type': 'bar',
-               'refs': [
-                   {'id': '123', 'type': 'baz'},
-                   {'id': '234', 'type': 'baz'},
-                   {'id': '234', 'type': 'foo'}
-               ]
-           } == delete_ref_duplicates(data)
+        'id': '123',
+        'name': 'foo',
+        'type': 'bar',
+        'refs': [
+            {'id': '123', 'type': 'baz'},
+            {'id': '234', 'type': 'baz'},
+            {'id': '234', 'type': 'foo'}
+        ]
+    } == delete_ref_duplicates(data)
 
 
 def test_delete_ref_duplicates_with_object_containing_duplicate_refs_in_nested_object():
@@ -361,14 +361,14 @@ def test_delete_ref_duplicates_with_object_containing_duplicate_refs_in_nested_o
         }
     }
     assert {
-               'id': '123',
-               'name': 'foo',
-               'type': 'bar',
-               'children': {
-                   'refs': [
-                       {'id': '123', 'type': 'baz'},
-                       {'id': '234', 'type': 'baz'},
-                       {'id': '234', 'type': 'foo'}
-                   ]
-               }
-           } == delete_ref_duplicates(data)
+        'id': '123',
+        'name': 'foo',
+        'type': 'bar',
+        'children': {
+            'refs': [
+                {'id': '123', 'type': 'baz'},
+                {'id': '234', 'type': 'baz'},
+                {'id': '234', 'type': 'foo'}
+            ]
+        }
+    } == delete_ref_duplicates(data)


### PR DESCRIPTION
This PR fixes #79 issue: it updates object comparison logic (used for idempotency) to dedupe reference arrays before comparing them. In case array contains more than one reference to the same object, duplicates are removed and ignored in comparison.

With this PR, the playbook from the issue becomes idempotent:
![screen shot 2019-03-06 at 6 01 53 pm](https://user-images.githubusercontent.com/4347159/53895272-53387300-403a-11e9-886b-7dc1c2103dee.png)