### PR TITLE
Bugfix: 'getList' operations failed without 'register_as' parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [v0.2.2] - 2019-06-06
+### Fixed
+- Usage of `register_as` parameter in `ftd_configuration` module.
+
 ## [v0.2.1] - 2019-05-23
 ### Added
 - Ansible playbooks for configuring DHCP servers and Static Routes.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG PYTHON_VERSION=3.6
 FROM python:${PYTHON_VERSION}
-ARG FTD_ANSIBLE_VERSION=v0.2.1
+ARG FTD_ANSIBLE_VERSION=v0.2.2
 ARG FTD_ANSIBLE_FOLDER=ftd-ansible
 
 RUN wget https://github.com/CiscoDevNet/FTDAnsible/archive/${FTD_ANSIBLE_VERSION}.tar.gz && \

--- a/library/ftd_install.py
+++ b/library/ftd_install.py
@@ -37,7 +37,7 @@ description:
     the `local` connection should be used only when the device cannot be accessed via
     REST API.
 version_added: "2.8"
-requirements: [ "python >= 3.5", "kick" ]
+requirements: [ "python >= 3.5", "firepower-kickstart" ]
 author: "Cisco Systems, Inc."
 options:
   device_hostname:
@@ -234,7 +234,8 @@ def main():
     module = AnsibleModule(argument_spec=fields)
     if not HAS_KICK:
         module.fail_json(msg='Kick Python module is required to run this module. '
-                             'Please, install it with `pip install kick` command and run the playbook again.')
+                             'Please, install it with `pip install firepower-kickstart` '
+                             'command and run the playbook again.')
 
     use_local_connection = module._socket_path is None
     if use_local_connection:

--- a/module_utils/common.py
+++ b/module_utils/common.py
@@ -66,7 +66,7 @@ def construct_ansible_facts(response, params):
         response_body = response['items'] if 'items' in response else response
         if params.get('register_as'):
             facts[params['register_as']] = response_body
-        elif response_body.get('name') and response_body.get('type'):
+        elif type(response_body) is dict and response_body.get('name') and response_body.get('type'):
             object_name = re.sub(INVALID_IDENTIFIER_SYMBOLS, '_', response_body['name'].lower())
             fact_name = '%s_%s' % (response_body['type'], object_name)
             facts[fact_name] = response_body

--- a/samples/test_ftd_configuration_register_as.yml
+++ b/samples/test_ftd_configuration_register_as.yml
@@ -1,0 +1,54 @@
+- hosts: vftd
+  connection: httpapi
+
+  tasks:
+    - name: Single-object response must be registered as 'TYPE_NAME' when 'register_as' is absent
+      ftd_configuration:
+        operation: upsertNetworkObject
+        data:
+          name: test-network
+          subType: NETWORK
+          value: 192.23.23.0/24
+          type: networkobject
+    - assert:
+        that:
+          - networkobject_test_network != None
+          - networkobject_test_network.name == "test-network"
+
+    - name: Single-object response must be registered as 'register_as' value when 'register_as' is present
+      ftd_configuration:
+        operation: upsertNetworkObject
+        data:
+          name: test-network
+          subType: NETWORK
+          value: 192.23.23.0/24
+          type: networkobject
+        register_as: test_network
+    - assert:
+        that:
+          - test_network != None
+          - test_network.name  == "test-network"
+
+    - name: List-object response must be ignored when 'register_as' is absent
+      ftd_configuration:
+        operation: getNetworkObjectList
+        query_params:
+          filter: "name:test-network"
+
+    - name: List-object response must be registered as 'register_as' value when 'register_as' is present
+      ftd_configuration:
+        operation: getNetworkObjectList
+        query_params:
+          filter: "name:test-network"
+        register_as: networks
+    - assert:
+       that:
+         - networks != None
+         - networks | length == 1
+         - networks.0.name == "test-network"
+
+    - name: Delete created Network Object
+      ftd_configuration:
+        operation: deleteNetworkObject
+        path_params:
+          objId: "{{ test_network.id }}"

--- a/test/unit/module_utils/test_common.py
+++ b/test/unit/module_utils/test_common.py
@@ -16,7 +16,7 @@
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from module_utils.common import equal_objects, delete_ref_duplicates
+from module_utils.common import equal_objects, delete_ref_duplicates, construct_ansible_facts
 
 
 # simple objects
@@ -372,3 +372,75 @@ def test_delete_ref_duplicates_with_object_containing_duplicate_refs_in_nested_o
             ]
         }
     } == delete_ref_duplicates(data)
+
+
+def test_construct_ansible_facts_should_make_default_fact_with_name_and_type():
+    response = {
+        'id': '123',
+        'name': 'foo',
+        'type': 'bar'
+    }
+
+    assert {'bar_foo': response} == construct_ansible_facts(response, {})
+
+
+def test_construct_ansible_facts_should_not_make_default_fact_with_no_name():
+    response = {
+        'id': '123',
+        'name': 'foo'
+    }
+
+    assert {} == construct_ansible_facts(response, {})
+
+
+def test_construct_ansible_facts_should_not_make_default_fact_with_no_type():
+    response = {
+        'id': '123',
+        'type': 'bar'
+    }
+
+    assert {} == construct_ansible_facts(response, {})
+
+
+def test_construct_ansible_facts_should_use_register_as_when_given():
+    response = {
+        'id': '123',
+        'name': 'foo',
+        'type': 'bar'
+    }
+    params = {'register_as': 'fact_name'}
+
+    assert {'fact_name': response} == construct_ansible_facts(response, params)
+
+
+def test_construct_ansible_facts_should_extract_items():
+    response = {'items': [
+        {
+            'id': '123',
+            'name': 'foo',
+            'type': 'bar'
+        }, {
+            'id': '123',
+            'name': 'foo',
+            'type': 'bar'
+        }
+    ]}
+    params = {'register_as': 'fact_name'}
+
+    assert {'fact_name': response['items']} == construct_ansible_facts(response, params)
+
+
+def test_construct_ansible_facts_should_ignore_items_with_no_register_as():
+    response = {'items': [
+        {
+            'id': '123',
+            'name': 'foo',
+            'type': 'bar'
+        }, {
+            'id': '123',
+            'name': 'foo',
+            'type': 'bar'
+        }
+    ]}
+
+    assert {} == construct_ansible_facts(response, {})


### PR DESCRIPTION
This PR fixes a bug with `getList` operation. When executing a play with `ftd_configuration` module, `getList` operation and NO `register_as` parameter, the play failed with the following error.

Play example:

```
      ftd_configuration:
        operation: getNetworkObjectList
        query_params:
          filter: "name:test-network"
```

Stacktrace:
```
  File "/common.py", line 69, in construct_ansible_facts
    elif response_body.get('name') and response_body.get('type'):
AttributeError: 'list' object has no attribute 'get'
```

The reason is that the server returns a list of objects and we treated them as a dictionary instead.