### PR TITLE
Install sshpass as part of Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,9 @@ FROM python:${PYTHON_VERSION}
 ARG FTD_ANSIBLE_VERSION=v0.2.1
 ARG FTD_ANSIBLE_FOLDER=ftd-ansible
 
-RUN apt-get update && apt-get install sshpass
+RUN apt-get update && \
+    apt-get install -yq sshpass && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 RUN wget https://github.com/CiscoDevNet/FTDAnsible/archive/${FTD_ANSIBLE_VERSION}.tar.gz && \
     tar -xvf ${FTD_ANSIBLE_VERSION}.tar.gz

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,8 @@ FROM python:${PYTHON_VERSION}
 ARG FTD_ANSIBLE_VERSION=v0.2.1
 ARG FTD_ANSIBLE_FOLDER=ftd-ansible
 
+RUN apt-get update && apt-get install sshpass
+
 RUN wget https://github.com/CiscoDevNet/FTDAnsible/archive/${FTD_ANSIBLE_VERSION}.tar.gz && \
     tar -xvf ${FTD_ANSIBLE_VERSION}.tar.gz
 


### PR DESCRIPTION
This PR updates Dockerfile to install `sshpass` package while building the image. It's necessary if we want to run Ansible tasks with SSH connection on `ftd-ansible` image. Without `sshpass` installed, it doesn't work:

```
FAILED! => {"msg": "to use the 'ssh' connection type with passwords, you must install the sshpass program"}
```