### PR TITLE
Change state when receiving 204 status for DELETE requests

### DIFF
--- a/module_utils/configuration.py
+++ b/module_utils/configuration.py
@@ -431,7 +431,9 @@ class BaseConfigurationResource(object):
                                            path_params=path_params, query_params=query_params)
         raise_for_failure(response)
 
-        if http_method != HTTPMethod.GET and response[ResponseParams.STATUS_CODE] != NO_CONTENT_STATUS:
+        is_unsafe_method = http_method != HTTPMethod.GET
+        config_changed = response[ResponseParams.STATUS_CODE] != NO_CONTENT_STATUS or http_method == HTTPMethod.DELETE
+        if is_unsafe_method and config_changed:
             self.config_changed = True
         return response[ResponseParams.RESPONSE]
 


### PR DESCRIPTION
When `DELETE` requests return 204 response, it means that the object was successfully deleted, so we should change `config_changed` flag to `True`. For other requests, this flag should remain unchanged.