### PR TITLE
Do not require type in Swagger Docs

### DIFF
--- a/module_utils/fdm_swagger_client.py
+++ b/module_utils/fdm_swagger_client.py
@@ -545,7 +545,7 @@ class FdmSwaggerValidator:
         for prop in model_properties.keys():
             if prop in data:
                 model_prop_val = model_properties[prop]
-                expected_type = model_prop_val[PropName.TYPE]
+                expected_type = model_prop_val.get(PropName.TYPE, PropType.OBJECT)
                 actually_value = data[prop]
                 self._check_types(status, actually_value, expected_type, model_prop_val, path, prop)
 
@@ -579,8 +579,8 @@ class FdmSwaggerValidator:
         else:
             item_model = model[PropName.ITEMS]
             for i, item_data in enumerate(data):
-                self._check_types(status, item_data, item_model[PropName.TYPE], item_model, "{0}[{1}]".format(path, i),
-                                  '')
+                model_type = item_model.get(PropName.TYPE, PropType.OBJECT)
+                self._check_types(status, item_data, model_type, item_model, "{0}[{1}]".format(path, i), '')
 
     @staticmethod
     def _is_correct_simple_types(expected_type, value, allow_null=True):
@@ -635,4 +635,4 @@ class FdmSwaggerValidator:
 
     @staticmethod
     def _is_object(model):
-        return PropName.TYPE in model and model[PropName.TYPE] == PropType.OBJECT
+        return PropName.REF in model or model.get(PropName.TYPE) == PropType.OBJECT

--- a/test/unit/module_utils/test_fdm_swagger_validator.py
+++ b/test/unit/module_utils/test_fdm_swagger_validator.py
@@ -900,6 +900,22 @@ class TestFdmSwaggerValidator(unittest.TestCase):
         assert valid
         assert rez is None
 
+    def test_nested_required_fields_for_spec_without_object_type(self):
+        spec_without_object_type = copy.deepcopy(nested_mock_data1)
+        del spec_without_object_type['models']['model1']['type']
+        del spec_without_object_type['models']['TestModel']['type']
+        del spec_without_object_type['models']['TestModel']['properties']['nested_model']['type']
+
+        valid_data = {
+            'nested_model': {
+                'f_string': "test"
+            }
+        }
+        valid, rez = FdmSwaggerValidator(spec_without_object_type).validate_data('getdata', valid_data)
+
+        assert valid
+        assert rez is None
+
     def test_invalid_nested_required_fields(self):
         invalid_data = {
             'f_integer': 2

--- a/test/unit/module_utils/test_upsert_functionality.py
+++ b/test/unit/module_utils/test_upsert_functionality.py
@@ -343,7 +343,8 @@ class TestUpsertOperationFunctionalTests(object):
             elif http_method == HTTPMethod.GET:
                 return {
                     ResponseParams.SUCCESS: True,
-                    ResponseParams.RESPONSE: {'items': []}
+                    ResponseParams.RESPONSE: {'items': []},
+                    ResponseParams.STATUS_CODE: 200,
                 }
             else:
                 assert False
@@ -404,7 +405,8 @@ class TestUpsertOperationFunctionalTests(object):
         connection_mock.get_operation_specs_by_model_name.return_value = operations
         connection_mock.send_request.return_value = {
             ResponseParams.SUCCESS: True,
-            ResponseParams.RESPONSE: {'items': []}
+            ResponseParams.RESPONSE: {'items': []},
+            ResponseParams.STATUS_CODE: 200,
         }
         params = {
             'operation': 'upsertObject',
@@ -464,7 +466,8 @@ class TestUpsertOperationFunctionalTests(object):
                             {'name': 'testObject', 'value': old_value, 'type': 'object', 'id': obj_id,
                              'version': version}
                         ]
-                    }
+                    },
+                    ResponseParams.STATUS_CODE: 200,
                 }
             elif http_method == HTTPMethod.PUT:
                 assert url_path == url_with_id_templ
@@ -537,7 +540,8 @@ class TestUpsertOperationFunctionalTests(object):
                     ResponseParams.SUCCESS: True,
                     ResponseParams.RESPONSE: {
                         'items': [expected_val]
-                    }
+                    },
+                    ResponseParams.STATUS_CODE: 200,
                 }
             else:
                 assert False
@@ -602,6 +606,7 @@ class TestUpsertOperationFunctionalTests(object):
                 return {
                     ResponseParams.SUCCESS: True,
                     ResponseParams.RESPONSE: expected_val,
+                    ResponseParams.STATUS_CODE: 200,
                 }
             elif http_method == HTTPMethod.GET:
                 assert url_path == url
@@ -615,6 +620,7 @@ class TestUpsertOperationFunctionalTests(object):
                     ResponseParams.RESPONSE: {
                         'items': [expected_val]
                     },
+                    ResponseParams.STATUS_CODE: 200,
                 }
             else:
                 assert False
@@ -698,7 +704,8 @@ class TestUpsertOperationFunctionalTests(object):
                     ResponseParams.SUCCESS: True,
                     ResponseParams.RESPONSE: {
                         'items': []
-                    }
+                    },
+                    ResponseParams.STATUS_CODE: 200,
                 }
             else:
                 assert False
@@ -777,7 +784,8 @@ class TestUpsertOperationFunctionalTests(object):
                             {'name': 'testObject', 'value': old_value, 'type': 'object', 'id': obj_id,
                              'version': version}
                         ]
-                    }
+                    },
+                    ResponseParams.STATUS_CODE: 200,
                 }
             elif http_method == HTTPMethod.PUT:
                 assert url_path == url_with_id_templ
@@ -897,7 +905,8 @@ class TestUpsertOperationFunctionalTests(object):
                     ResponseParams.SUCCESS: True,
                     ResponseParams.RESPONSE: {
                         'items': [sample_obj, sample_obj]
-                    }
+                    },
+                    ResponseParams.STATUS_CODE: 200,
                 }
             else:
                 assert False


### PR DESCRIPTION
In the latest Swagger docs, the `type` property is omitted for objects. This PR updates our Swagger parser to comply with this change and treat properties with no type as object properties.

__BEFORE__
![Screen Shot 2019-09-24 at 1 17 52 PM](https://user-images.githubusercontent.com/4347159/68762558-1720cd80-061f-11ea-9048-487c870a9841.png)

__AFTER__
![Screen Shot 2019-09-24 at 1 14 42 PM](https://user-images.githubusercontent.com/4347159/68762549-112aec80-061f-11ea-9bb6-9f63704bcb28.png)
